### PR TITLE
Fix subtleBounce keyframes typos

### DIFF
--- a/src/styles/keyframes.ts
+++ b/src/styles/keyframes.ts
@@ -153,10 +153,10 @@ export const underlineAnimation = keyframes`
 `;
 
 export const subtleBounce = keyframes`
-  0%, 100% { 
-    transform: tranlateY(0);
+  0%, 100% {
+    transform: translateY(0);
   }
   50% {
-    transfomr: translateY(-10px);
+    transform: translateY(-10px);
   }
 `;


### PR DESCRIPTION
## Summary
- correct typographical errors in subtleBounce keyframes

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844761b79e8832e88b24ca9b79000c3