### PR TITLE
Fix contact form error states

### DIFF
--- a/src/app/components/Contact/ContactContent.tsx
+++ b/src/app/components/Contact/ContactContent.tsx
@@ -187,7 +187,7 @@ const ContactContent: React.FC = () => {
                     </FormControl>
                   </Grid>
                   <Grid size={{ xs: 12, sm: 6 }}>
-                    <FormControl fullWidth error={!!errors.name}>
+                    <FormControl fullWidth error={!!errors.email}>
                       <TextField
                         name="email"
                         label="Email"
@@ -196,6 +196,7 @@ const ContactContent: React.FC = () => {
                         error={!!errors.email}
                         variant="standard"
                       />
+                      <FormHelperText>{errors.email}</FormHelperText>
                     </FormControl>
                   </Grid>
                   <Grid size={{ xs: 12, sm: 6 }}>
@@ -208,8 +209,9 @@ const ContactContent: React.FC = () => {
                         variant="standard"
                         value={formState.message}
                         onChange={handleChange}
-                        error={!!errors.email}
+                        error={!!errors.message}
                       />
+                      <FormHelperText>{errors.message}</FormHelperText>
                     </FormControl>
                   </Grid>
                   <Grid size={{ xs: 12, sm: 6 }}>


### PR DESCRIPTION
## Summary
- fix email field error highlighting
- show validation helper text for email and message fields

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844761988f4832eb293a756d55bee4f