### PR TITLE
chore: configure Prettier, ESLint, and CI linting workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": [
+    "next/core-web-vitals",
+    "prettier"
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,3 @@
 {
-  "extends": [
-    "next/core-web-vitals",
-    "prettier"
-  ]
+  "extends": ["next/core-web-vitals", "prettier"]
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint & Format
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache pnpm store
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --store-dir ~/.pnpm-store
+
+      - name: Run Prettier
+        run: pnpm exec prettier --check .
+
+      - name: Run ESLint
+        run: pnpm run lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,8 @@
-!src/data/*.json
+# Ignore artifacts
+.node_modules
+.next
+out
+build
+public
+*.yml
+*.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+    "semi": false,
+    "singleQuote": false,
+    "printWidth": 80,
+    "tabWidth": 2,
+    "trailingComma": "all",
+    "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,8 @@
 {
-    "semi": false,
-    "singleQuote": false,
-    "printWidth": 80,
-    "tabWidth": 2,
-    "trailingComma": "all",
-    "plugins": ["prettier-plugin-organize-imports"]
+  "semi": false,
+  "singleQuote": false,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/loader.ts
+++ b/loader.ts
@@ -1,7 +1,7 @@
 interface ImgixLoaderParams {
-  src: string;
-  width: number;
-  quality?: number;
+  src: string
+  width: number
+  quality?: number
 }
 
 export default function imgixLoader({
@@ -9,11 +9,11 @@ export default function imgixLoader({
   width,
   quality,
 }: ImgixLoaderParams): string {
-  const url = new URL(`https://personal-portfolio-products.imgix.net/${src}`);
-  const params = url.searchParams;
+  const url = new URL(`https://personal-portfolio-products.imgix.net/${src}`)
+  const params = url.searchParams
 
-  params.set("auto", params.getAll("auto").join(",") || "format");
-  params.set("fit", params.get("fit") || "max");
-  params.set("w", params.get("w") || width.toString());
-  return url.href;
+  params.set("auto", params.getAll("auto").join(",") || "format")
+  params.set("fit", params.get("fit") || "max")
+  params.set("w", params.get("w") || width.toString())
+  return url.href
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,16 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    images: {
-        formats: ["image/avif", "image/webp"],
-        remotePatterns: [
-            {
-                protocol: "https",
-                hostname: "personal-portfolio-products.imgix.net",
-            },
-        ],
-        loader: "custom",
-        loaderFile: "loader.ts",
-    }
-};
+  images: {
+    formats: ["image/avif", "image/webp"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "personal-portfolio-products.imgix.net",
+      },
+    ],
+    loader: "custom",
+    loaderFile: "loader.ts",
+  },
+}
 
-export default nextConfig;
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/react-dom": "^18.3.7",
     "eslint": "^9.28.0",
     "eslint-config-next": "latest",
+    "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-perfectionist": "^4.14.0",
     "prettier": "^3.5.3",
     "prettier-plugin-organize-imports": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@emotion/cache": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-config-next": "latest",
     "eslint-plugin-perfectionist": "^4.14.0",
     "prettier": "^3.5.3",
+    "prettier-plugin-organize-imports": "^4.1.0",
     "typescript": "^5.8.3"
   },
   "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       eslint-config-next:
         specifier: latest
         version: 15.3.3(eslint@9.28.0)(typescript@5.8.3)
+      eslint-config-prettier:
+        specifier: ^10.1.5
+        version: 10.1.5(eslint@9.28.0)
       eslint-plugin-perfectionist:
         specifier: ^4.14.0
         version: 4.14.0(eslint@9.28.0)(typescript@5.8.3)
@@ -1114,6 +1117,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  eslint-config-prettier@10.1.5:
+    resolution: {integrity: sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
 
   eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
@@ -3183,8 +3192,8 @@ snapshots:
       '@typescript-eslint/parser': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
       eslint: 9.28.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.28.0)
       eslint-plugin-react: 7.37.5(eslint@9.28.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.28.0)
@@ -3195,6 +3204,10 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
+  eslint-config-prettier@10.1.5(eslint@9.28.0):
+    dependencies:
+      eslint: 9.28.0
+
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
@@ -3203,7 +3216,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -3214,22 +3227,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.7.11
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0))(eslint@9.28.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
       eslint: 9.28.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3240,7 +3253,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.28.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0))(eslint@9.28.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      prettier-plugin-organize-imports:
+        specifier: ^4.1.0
+        version: 4.1.0(prettier@3.5.3)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1752,6 +1755,16 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-plugin-organize-imports@4.1.0:
+    resolution: {integrity: sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
+
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
@@ -3170,8 +3183,8 @@ snapshots:
       '@typescript-eslint/parser': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
       eslint: 9.28.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.28.0)
       eslint-plugin-react: 7.37.5(eslint@9.28.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.28.0)
@@ -3190,7 +3203,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -3201,22 +3214,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.7.11
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0))(eslint@9.28.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
       eslint: 9.28.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3227,7 +3240,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.28.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0))(eslint@9.28.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0))(eslint@9.28.0))(eslint@9.28.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3894,6 +3907,11 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-organize-imports@4.1.0(prettier@3.5.3)(typescript@5.8.3):
+    dependencies:
+      prettier: 3.5.3
+      typescript: 5.8.3
 
   prettier@3.5.3: {}
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,7 @@
-import type { Metadata } from "next";
-import NavBar from "../components/Navbar";
-import AboutProvider from "@/contexts/AboutContext";
-import AboutContent from "../components/AboutMe/AboutContent";
+import AboutProvider from "@/contexts/AboutContext"
+import type { Metadata } from "next"
+import AboutContent from "../components/AboutMe/AboutContent"
+import NavBar from "../components/Navbar"
 
 export const metadata: Metadata = {
   title: "About Me",
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "https://dev.nickbrady.dev/about",
   },
-};
+}
 
 export default function About() {
   return (
@@ -21,5 +21,5 @@ export default function About() {
         <AboutContent />
       </AboutProvider>
     </>
-  );
+  )
 }

--- a/src/app/components/AboutMe/AboutContent.tsx
+++ b/src/app/components/AboutMe/AboutContent.tsx
@@ -1,20 +1,19 @@
-"use client";
-import React from "react";
-import { Container, Typography, Grid2 as Grid } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
-import { useAboutContext } from "@/contexts/AboutContext";
-import { TimelineSection } from "./TimelineSection";
-import FooterLink from "../FooterLink";
-import { motion } from "framer-motion";
-import { useTransitions } from "@/hooks/useTransitions";
+"use client"
+import { useAboutContext } from "@/contexts/AboutContext"
+import { useTransitions } from "@/hooks/useTransitions"
+import { Container, Grid2 as Grid, Typography } from "@mui/material"
+import { useTheme } from "@mui/material/styles"
+import { motion } from "framer-motion"
+import FooterLink from "../FooterLink"
+import { TimelineSection } from "./TimelineSection"
 
 const AboutContent = () => {
-  const theme = useTheme();
-  const { aboutMeData, myPlaylistData, myPhotographyData } = useAboutContext();
-  const motionPropsOne = useTransitions(0.2);
-  const motionPropsTwo = useTransitions(0.4);
-  const motionPropsThree = useTransitions(0.6);
-  const motionPropsFooter = useTransitions(0.7);
+  const theme = useTheme()
+  const { aboutMeData, myPlaylistData, myPhotographyData } = useAboutContext()
+  const motionPropsOne = useTransitions(0.2)
+  const motionPropsTwo = useTransitions(0.4)
+  const motionPropsThree = useTransitions(0.6)
+  const motionPropsFooter = useTransitions(0.7)
 
   return (
     <>
@@ -86,7 +85,7 @@ const AboutContent = () => {
         </Grid>
       </Container>
     </>
-  );
-};
+  )
+}
 
-export default AboutContent;
+export default AboutContent

--- a/src/app/components/AboutMe/TimelineSection.tsx
+++ b/src/app/components/AboutMe/TimelineSection.tsx
@@ -1,29 +1,28 @@
-import React from "react";
+import { TimelineItemType } from "@/contexts/AboutContext"
 import {
   Timeline,
-  TimelineItem,
-  TimelineSeparator,
   TimelineConnector,
   TimelineContent,
-  timelineItemClasses,
   TimelineDot,
-  TimelineOppositeContent,
-} from "@mui/lab";
-import { Typography, Box, LinkProps } from "@mui/material";
-import CustomLink from "../CustomLink";
-import { useTheme } from "@mui/material/styles";
-import { TimelineItemType } from "@/contexts/AboutContext";
+  TimelineItem,
+  timelineItemClasses,
+  TimelineSeparator,
+} from "@mui/lab"
+import { Box, Typography } from "@mui/material"
+import { useTheme } from "@mui/material/styles"
+import React from "react"
+import CustomLink from "../CustomLink"
 
 type TimelineSectionProps = {
-  title?: string;
-  items: TimelineItemType[];
-};
+  title?: string
+  items: TimelineItemType[]
+}
 
 export const TimelineSection: React.FC<TimelineSectionProps> = ({
   title,
   items,
 }) => {
-  const theme = useTheme();
+  const theme = useTheme()
 
   // TODO: add underline highlight to the item title's
   return (
@@ -120,5 +119,5 @@ export const TimelineSection: React.FC<TimelineSectionProps> = ({
         ))}
       </Timeline>
     </Box>
-  );
-};
+  )
+}

--- a/src/app/components/Contact/ContactContent.tsx
+++ b/src/app/components/Contact/ContactContent.tsx
@@ -1,40 +1,38 @@
-"use client";
-import React, { ChangeEvent, useState, FormEvent } from "react";
+"use client"
+import { useTransitions } from "@/hooks/useTransitions"
 import {
-  Typography,
-  Container,
-  TextField,
-  Button,
+  AlertColor,
   Box,
-  Grid2 as Grid,
+  Button,
+  Container,
   FormControl,
   FormHelperText,
-  Snackbar,
-  Alert,
-  AlertColor,
-  useTheme,
+  Grid2 as Grid,
   styled,
-} from "@mui/material";
-import { motion } from "framer-motion";
-import { useTransitions } from "@/hooks/useTransitions";
-import FooterLink from "../FooterLink";
+  TextField,
+  Typography,
+  useTheme,
+} from "@mui/material"
+import { motion } from "framer-motion"
+import React, { ChangeEvent, FormEvent, useState } from "react"
+import FooterLink from "../FooterLink"
 
 interface FormData {
-  name: string;
-  email: string;
-  message: string;
+  name: string
+  email: string
+  message: string
 }
 
 interface FormErrors {
-  name?: string;
-  email?: string;
-  message?: string;
+  name?: string
+  email?: string
+  message?: string
 }
 
 interface SnackbarState {
-  open: boolean;
-  message: string;
-  severity: AlertColor;
+  open: boolean
+  message: string
+  severity: AlertColor
 }
 
 const StyledForm = styled("form")(({ theme }) => ({
@@ -44,53 +42,53 @@ const StyledForm = styled("form")(({ theme }) => ({
   "&. MuiButton-root": {
     marginBottom: theme.spacing(4),
   },
-}));
+}))
 
 const ContactContent: React.FC = () => {
   const [formState, setFormState] = useState<FormData>({
     name: "",
     email: "",
     message: "",
-  });
-  const [errors, setErrors] = useState<FormErrors>({});
+  })
+  const [errors, setErrors] = useState<FormErrors>({})
   const [snackbar, setSnackbar] = useState<SnackbarState>({
     open: false,
     message: "",
     severity: "success",
-  });
-  const theme = useTheme();
-  const motionPropsHeading = useTransitions(0.2);
-  const motionPropsIntro = useTransitions(0.4);
-  const motionPropsForm = useTransitions(0.6);
-  const motionPropsFooter = useTransitions(0.8);
+  })
+  const theme = useTheme()
+  const motionPropsHeading = useTransitions(0.2)
+  const motionPropsIntro = useTransitions(0.4)
+  const motionPropsForm = useTransitions(0.6)
+  const motionPropsFooter = useTransitions(0.8)
 
   const handleChange = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
-    const { name, value } = event.target;
+    const { name, value } = event.target
     setFormState((prevState) => ({
       ...prevState,
       [name]: value,
-    }));
-  };
+    }))
+  }
 
   const validateForm = (): boolean => {
-    let tempErrors: FormErrors = {};
-    if (!formState.name) tempErrors.name = "Name is required";
+    let tempErrors: FormErrors = {}
+    if (!formState.name) tempErrors.name = "Name is required"
     if (!formState.email) {
-      tempErrors.email = "Email is required";
+      tempErrors.email = "Email is required"
     } else if (
       !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(formState.email)
     ) {
-      tempErrors.email = "Invalid email address";
+      tempErrors.email = "Invalid email address"
     }
-    if (!formState.message) tempErrors.message = "Message is required";
-    setErrors(tempErrors);
-    return Object.keys(tempErrors).length === 0;
-  };
+    if (!formState.message) tempErrors.message = "Message is required"
+    setErrors(tempErrors)
+    return Object.keys(tempErrors).length === 0
+  }
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+    event.preventDefault()
 
     if (validateForm()) {
       try {
@@ -100,7 +98,7 @@ const ContactContent: React.FC = () => {
             "Content-Type": "application/json",
           },
           body: JSON.stringify(formState),
-        });
+        })
 
         if (response.ok) {
           setSnackbar({
@@ -108,29 +106,29 @@ const ContactContent: React.FC = () => {
             message: "Message sent successfully!",
             severity: "success",
           }),
-            setFormState({ name: "", email: "", message: "" });
+            setFormState({ name: "", email: "", message: "" })
         } else {
-          throw new Error("Form submission failed.");
+          throw new Error("Form submission failed.")
         }
       } catch (error) {
         setSnackbar({
           open: true,
           message: "Failed to send message. Please try again.",
           severity: "error",
-        });
+        })
       }
     }
-  };
+  }
 
   const handleCloseSnackbar = (
     _event: React.SyntheticEvent | Event,
-    reason?: string
+    reason?: string,
   ) => {
     if (reason === "clickway") {
-      return;
+      return
     }
-    setSnackbar((prevState) => ({ ...prevState, open: false }));
-  };
+    setSnackbar((prevState) => ({ ...prevState, open: false }))
+  }
 
   return (
     <>
@@ -251,7 +249,7 @@ const ContactContent: React.FC = () => {
         </Grid>
       </Container>
     </>
-  );
-};
+  )
+}
 
-export default ContactContent;
+export default ContactContent

--- a/src/app/components/CustomLink.tsx
+++ b/src/app/components/CustomLink.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import NextLink from "next/link";
-import { Link, LinkProps } from "@mui/material";
+import { Link, LinkProps } from "@mui/material"
+import NextLink from "next/link"
+import React from "react"
 
 interface CustomLinkProps extends Omit<LinkProps, "component"> {
-  href: string;
-  children: React.ReactNode;
+  href: string
+  children: React.ReactNode
 }
 
 const CustomLink: React.FC<CustomLinkProps> = ({
@@ -16,7 +16,7 @@ const CustomLink: React.FC<CustomLinkProps> = ({
     <Link component={NextLink} href={href} passHref {...props}>
       {children}
     </Link>
-  );
-};
+  )
+}
 
-export default CustomLink;
+export default CustomLink

--- a/src/app/components/CustomTabs.tsx
+++ b/src/app/components/CustomTabs.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
-import { Box, Tab } from "@mui/material";
-import { TabPanel, TabContext, TabList } from "@mui/lab";
-import { styled } from "@mui/material/styles";
+import { TabContext, TabList, TabPanel } from "@mui/lab"
+import { Box, Tab } from "@mui/material"
+import { styled } from "@mui/material/styles"
+import React, { useState } from "react"
 
 const StyledTab = styled(Tab)(({ theme }) => ({
   backgroundColor: "transparent",
@@ -14,24 +14,24 @@ const StyledTab = styled(Tab)(({ theme }) => ({
     color: theme.palette.common.white,
     backgroundColor: theme.palette.grey[800],
   },
-}));
+}))
 
 interface TabItem {
-  label: string;
-  content: React.ReactNode;
-  href?: string;
+  label: string
+  content: React.ReactNode
+  href?: string
 }
 
 interface CustomTabProps {
-  items: TabItem[];
+  items: TabItem[]
 }
 
 const CustomTabs: React.FC<CustomTabProps> = ({ items }) => {
-  const [value, setValue] = useState<string>("0");
+  const [value, setValue] = useState<string>("0")
 
   const handleChange = (event: React.SyntheticEvent, newValue: string) => {
-    setValue(newValue);
-  };
+    setValue(newValue)
+  }
 
   return (
     <Box
@@ -64,7 +64,7 @@ const CustomTabs: React.FC<CustomTabProps> = ({ items }) => {
         ))}
       </TabContext>
     </Box>
-  );
-};
+  )
+}
 
-export default CustomTabs;
+export default CustomTabs

--- a/src/app/components/FooterLink.tsx
+++ b/src/app/components/FooterLink.tsx
@@ -1,34 +1,34 @@
-import React from "react";
-import NextLink from "next/link";
+import { arrowBounce } from "@/styles/keyframes"
+import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt"
+import FacebookIcon from "@mui/icons-material/Facebook"
+import GitHubIcon from "@mui/icons-material/GitHub"
+import InstagramIcon from "@mui/icons-material/Instagram"
+import LinkedInIcon from "@mui/icons-material/LinkedIn"
+import TwitterIcon from "@mui/icons-material/Twitter"
 import {
   Box,
   BoxProps,
-  Typography,
-  Link,
-  TypographyProps,
   IconButton,
   IconProps,
+  Link,
+  Typography,
+  TypographyProps,
   useTheme,
-} from "@mui/material";
-import { styled } from "@mui/material/styles";
-import { arrowBounce, underlineAnimation } from "@/styles/keyframes";
-import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
-import TwitterIcon from "@mui/icons-material/Twitter";
-import FacebookIcon from "@mui/icons-material/Facebook";
-import LinkedInIcon from "@mui/icons-material/LinkedIn";
-import GitHubIcon from "@mui/icons-material/GitHub";
-import InstagramIcon from "@mui/icons-material/Instagram";
-import CustomLink from "./CustomLink";
+} from "@mui/material"
+import { styled } from "@mui/material/styles"
+import NextLink from "next/link"
+import React from "react"
+import CustomLink from "./CustomLink"
 
 interface IFooterLink {
-  children: string | React.ReactNode;
-  goto?: string;
+  children: string | React.ReactNode
+  goto?: string
 }
 
 interface SocialMediaItems {
-  icon: React.ReactElement<IconProps>;
-  url: string;
-  label: string;
+  icon: React.ReactElement<IconProps>
+  url: string
+  label: string
 }
 
 const AnimatedTypography = styled(Typography)<TypographyProps>(({ theme }) => ({
@@ -50,15 +50,15 @@ const AnimatedTypography = styled(Typography)<TypographyProps>(({ theme }) => ({
     transform: "scaleX(1)",
     transformOrigin: "bottom left",
   },
-}));
+}))
 
 const SocialMediaBox = styled(Box)<BoxProps>(({ theme }) => ({
   background: "transparent",
   padding: theme.spacing(2, 0),
-}));
+}))
 
 const FooterLink: React.FC<IFooterLink> = ({ children, goto = "/" }) => {
-  const theme = useTheme();
+  const theme = useTheme()
 
   const SocialMedias: SocialMediaItems[] = [
     {
@@ -86,7 +86,7 @@ const FooterLink: React.FC<IFooterLink> = ({ children, goto = "/" }) => {
       url: "https://instagram.com/nickbrady41",
       label: "Instagram",
     },
-  ];
+  ]
 
   return (
     <>
@@ -181,7 +181,7 @@ const FooterLink: React.FC<IFooterLink> = ({ children, goto = "/" }) => {
         ))}
       </Box>
     </>
-  );
-};
+  )
+}
 
-export default FooterLink;
+export default FooterLink

--- a/src/app/components/LandingPage/AnimatedTitle.tsx
+++ b/src/app/components/LandingPage/AnimatedTitle.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { Typography, Box } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
-import { noiseAnim, noiseAnim2 } from "@/styles/keyframes";
+import { noiseAnim, noiseAnim2 } from "@/styles/keyframes"
+import { Box, Typography } from "@mui/material"
+import { useTheme } from "@mui/material/styles"
+import React from "react"
 
 const AnimatedTitle: React.FC = () => {
-  const theme = useTheme();
+  const theme = useTheme()
 
   return (
     <Box
@@ -48,7 +48,7 @@ const AnimatedTitle: React.FC = () => {
         I&apos;m Nick Brady
       </Typography>
     </Box>
-  );
-};
+  )
+}
 
-export default AnimatedTitle;
+export default AnimatedTitle

--- a/src/app/components/LandingPage/IntroContent.tsx
+++ b/src/app/components/LandingPage/IntroContent.tsx
@@ -1,16 +1,16 @@
-"use client";
-import React from "react";
-import { Box, useTheme } from "@mui/material";
-import { motion } from "framer-motion";
-import { useTransitions } from "@/hooks/useTransitions";
-import AnimatedTitle from "./AnimatedTitle";
-import FooterLink from "../FooterLink";
-import IntroductionText from "./IntroductionText";
+"use client"
+import { useTransitions } from "@/hooks/useTransitions"
+import { Box, useTheme } from "@mui/material"
+import { motion } from "framer-motion"
+import React from "react"
+import FooterLink from "../FooterLink"
+import AnimatedTitle from "./AnimatedTitle"
+import IntroductionText from "./IntroductionText"
 
 const IntroPageContent: React.FC<{}> = ({}) => {
-  const theme = useTheme();
-  const motionPropsTitle = useTransitions(0.1);
-  const motionPropsFooter = useTransitions(0.7);
+  const theme = useTheme()
+  const motionPropsTitle = useTransitions(0.1)
+  const motionPropsFooter = useTransitions(0.7)
 
   return (
     <Box
@@ -37,7 +37,7 @@ const IntroPageContent: React.FC<{}> = ({}) => {
         <FooterLink goto="/about">See More About Me</FooterLink>
       </motion.div>
     </Box>
-  );
-};
+  )
+}
 
-export default IntroPageContent;
+export default IntroPageContent

--- a/src/app/components/LandingPage/IntroductionText.tsx
+++ b/src/app/components/LandingPage/IntroductionText.tsx
@@ -1,15 +1,15 @@
-import React from "react";
-import { Typography } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
-import CustomLink from "../CustomLink";
-import { motion } from "framer-motion";
+import { Typography } from "@mui/material"
+import { useTheme } from "@mui/material/styles"
+import { motion } from "framer-motion"
+import React from "react"
+import CustomLink from "../CustomLink"
 
-import { useTransitions } from "@/hooks/useTransitions";
+import { useTransitions } from "@/hooks/useTransitions"
 
 const IntroductionText: React.FC = () => {
-  const theme = useTheme();
-  const motionPropsFirst = useTransitions(0.2);
-  const motionPropsSecond = useTransitions(0.3);
+  const theme = useTheme()
+  const motionPropsFirst = useTransitions(0.2)
+  const motionPropsSecond = useTransitions(0.3)
 
   // TODO: make the link font black, underline and turn blue when hovered
   return (
@@ -94,7 +94,7 @@ const IntroductionText: React.FC = () => {
         </Typography>
       </motion.div>
     </>
-  );
-};
+  )
+}
 
-export default IntroductionText;
+export default IntroductionText

--- a/src/app/components/Layout.tsx
+++ b/src/app/components/Layout.tsx
@@ -1,10 +1,10 @@
-"use client";
-import React, { PropsWithChildren } from "react";
-import { Box, useTheme, Grid2 as Grid, Container } from "@mui/material";
-import NavBar from "./Navbar";
+"use client"
+import { Box, Container, Grid2 as Grid, useTheme } from "@mui/material"
+import React, { PropsWithChildren } from "react"
+import NavBar from "./Navbar"
 
 interface LayoutProps {
-  children: React.ReactNode;
+  children: React.ReactNode
 }
 interface PageWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
   // Additional props can be added here if needed
@@ -14,7 +14,7 @@ export const PageWrapper: React.FC<PropsWithChildren<PageWrapperProps>> = ({
   children,
   ...rest
 }) => {
-  const theme = useTheme();
+  const theme = useTheme()
 
   return (
     <Box component="section" sx={{ width: "100%" }} {...rest}>
@@ -38,8 +38,8 @@ export const PageWrapper: React.FC<PropsWithChildren<PageWrapperProps>> = ({
         {children}
       </Container>
     </Box>
-  );
-};
+  )
+}
 
 interface SectionWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
   // Additional props can be added here if needed
@@ -48,7 +48,7 @@ interface SectionWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
 export const SectionWrapper: React.FC<
   PropsWithChildren<SectionWrapperProps>
 > = ({ children, ...rest }) => {
-  const theme = useTheme();
+  const theme = useTheme()
 
   return (
     <Container component="section" {...rest}>
@@ -56,11 +56,11 @@ export const SectionWrapper: React.FC<
         <Grid size={{ xs: 12, md: 10 }}>{children}</Grid>
       </Grid>
     </Container>
-  );
-};
+  )
+}
 
 export const Layout: React.FC<LayoutProps> = ({ children }) => {
-  const theme = useTheme();
+  const theme = useTheme()
 
   return (
     <>
@@ -69,5 +69,5 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
       </Box>
       <SectionWrapper>{children}</SectionWrapper>
     </>
-  );
-};
+  )
+}

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -1,35 +1,35 @@
-"use client";
+"use client"
 
-import React, { useState } from "react";
+import useIsMobile from "@/hooks/useIsMobile"
+import CloseIcon from "@mui/icons-material/Close"
+import MenuIcon from "@mui/icons-material/Menu"
 import {
   AppBar,
   AppBarProps,
-  Toolbar,
-  Button,
   Box,
-  IconButton,
+  Button,
+  ButtonBaseProps,
   Drawer,
-  List,
+  IconButton,
   Link,
+  List,
   ListItemButton,
   ListItemText,
-  useTheme,
-  ButtonBaseProps,
+  Toolbar,
   ToolbarProps,
-} from "@mui/material";
-import { styled } from "@mui/material/styles";
-import NextLink from "next/link";
-import { usePathname } from "next/navigation";
-import Image from "next/image";
-import MenuIcon from "@mui/icons-material/Menu";
-import CloseIcon from "@mui/icons-material/Close";
-import useIsMobile from "@/hooks/useIsMobile";
+  useTheme,
+} from "@mui/material"
+import { styled } from "@mui/material/styles"
+import Image from "next/image"
+import NextLink from "next/link"
+import { usePathname } from "next/navigation"
+import React, { useState } from "react"
 
 const StyledAppBar = styled(AppBar)<AppBarProps>(({ theme }) => ({
   background: "transparent",
   boxShadow: "none",
   transition: "all 0.5s ease",
-}));
+}))
 
 const NavLinkButton = styled(Button)<ButtonBaseProps>(({ theme }) => ({
   color: theme.palette.text.primary,
@@ -52,7 +52,7 @@ const NavLinkButton = styled(Button)<ButtonBaseProps>(({ theme }) => ({
     left: 0,
     right: 0,
   },
-}));
+}))
 
 const LogoWrapper = styled(Box)({
   flexGrow: 1,
@@ -62,7 +62,7 @@ const LogoWrapper = styled(Box)({
   "&:hover": {
     cursor: "pointer",
   },
-});
+})
 
 const StyledToolbar = styled(Toolbar)<ToolbarProps>(({ theme }) => ({
   paddingLeft: theme.spacing(1.875),
@@ -82,31 +82,31 @@ const StyledToolbar = styled(Toolbar)<ToolbarProps>(({ theme }) => ({
   [theme.breakpoints.up("lg")]: {
     maxWidth: "1140px",
   },
-}));
+}))
 
 interface NavBarProps {}
 
 interface NavItem {
-  label: string;
-  path: string;
-  ariaLabel: string;
+  label: string
+  path: string
+  ariaLabel: string
 }
 
 interface ListItemButtonLinkProps {
-  href: string;
-  text: string;
-  ariaLabel: string;
+  href: string
+  text: string
+  ariaLabel: string
 }
 
 const NavBar: React.FC<NavBarProps> = () => {
-  const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
-  const pathname = usePathname();
-  const theme = useTheme();
-  const isMobile = useIsMobile();
+  const [drawerOpen, setDrawerOpen] = useState<boolean>(false)
+  const pathname = usePathname()
+  const theme = useTheme()
+  const isMobile = useIsMobile()
 
   const handleDrawerToggle = () => {
-    setDrawerOpen((prevState) => !prevState);
-  };
+    setDrawerOpen((prevState) => !prevState)
+  }
 
   const navItems: NavItem[] = [
     { label: "About", path: "/about", ariaLabel: "Navigate to the About Page" },
@@ -120,7 +120,7 @@ const NavBar: React.FC<NavBarProps> = () => {
       path: "/contact",
       ariaLabel: "Navigate to the Contacts Page",
     },
-  ];
+  ]
 
   const renderNavLinks = () => (
     <Box sx={{ display: { sm: "none", md: "block" } }}>
@@ -142,7 +142,7 @@ const NavBar: React.FC<NavBarProps> = () => {
           </Link>
         ))}
     </Box>
-  );
+  )
 
   const ListItemLinkButton: React.FC<ListItemButtonLinkProps> = ({
     href,
@@ -196,8 +196,8 @@ const NavBar: React.FC<NavBarProps> = () => {
           />
         </ListItemButton>
       </Link>
-    );
-  };
+    )
+  }
 
   const drawer = (
     <Box
@@ -238,7 +238,7 @@ const NavBar: React.FC<NavBarProps> = () => {
           ))}
       </List>
     </Box>
-  );
+  )
 
   return (
     <Box component="header" sx={{ py: theme.spacing(5) }}>
@@ -304,7 +304,7 @@ const NavBar: React.FC<NavBarProps> = () => {
         </Drawer>
       </nav>
     </Box>
-  );
-};
+  )
+}
 
-export default NavBar;
+export default NavBar

--- a/src/app/components/Projects/CustomCardMedia.tsx
+++ b/src/app/components/Projects/CustomCardMedia.tsx
@@ -1,53 +1,53 @@
-import React, { useState, useEffect, useRef, forwardRef } from "react";
-import CardMedia, { CardMediaProps } from "@mui/material/CardMedia";
+import CardMedia, { CardMediaProps } from "@mui/material/CardMedia"
+import { forwardRef, useEffect, useRef, useState } from "react"
 
 interface ImgixLoaderParams {
-  src: string;
-  width?: number;
-  quality?: number;
+  src: string
+  width?: number
+  quality?: number
 }
 
 function imgixLoader({ src, width, quality = 75 }: ImgixLoaderParams): string {
-  const url = new URL(`https://personal-portfolio-products.imgix.net/${src}`);
-  const params = url.searchParams;
+  const url = new URL(`https://personal-portfolio-products.imgix.net/${src}`)
+  const params = url.searchParams
 
-  params.set("auto", params.getAll("auto").join(",") || "format");
-  params.set("fit", params.get("fit") || "max");
+  params.set("auto", params.getAll("auto").join(",") || "format")
+  params.set("fit", params.get("fit") || "max")
   if (width) {
-    params.set("w", width.toString());
+    params.set("w", width.toString())
   }
-  params.set("q", quality.toString());
-  return url.href;
+  params.set("q", quality.toString())
+  return url.href
 }
 
 interface CustomCardMediaProps extends Omit<CardMediaProps, "image"> {
-  src: string;
-  quality?: number;
+  src: string
+  quality?: number
 }
 
 const CustomCardMedia = forwardRef<HTMLDivElement, CustomCardMediaProps>(
   ({ src, quality, ...props }, ref) => {
-    const [width, setWidth] = useState<number | undefined>(undefined);
-    const mediaRef = useRef<HTMLDivElement>(null);
+    const [width, setWidth] = useState<number | undefined>(undefined)
+    const mediaRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
       const updateWidth = () => {
         if (mediaRef.current) {
-          setWidth(mediaRef.current.offsetWidth);
+          setWidth(mediaRef.current.offsetWidth)
         }
-      };
+      }
 
-      updateWidth();
-      window.addEventListener("resize", updateWidth);
-      return () => window.removeEventListener("resize", updateWidth);
-    }, []);
+      updateWidth()
+      window.addEventListener("resize", updateWidth)
+      return () => window.removeEventListener("resize", updateWidth)
+    }, [])
 
-    const imageUrl = imgixLoader({ src, width, quality });
+    const imageUrl = imgixLoader({ src, width, quality })
 
-    return <CardMedia ref={ref} src={imageUrl} {...props} />;
-  }
-);
+    return <CardMedia ref={ref} src={imageUrl} {...props} />
+  },
+)
 
-CustomCardMedia.displayName = "CustomCardMedia";
+CustomCardMedia.displayName = "CustomCardMedia"
 
-export default CustomCardMedia;
+export default CustomCardMedia

--- a/src/app/components/Projects/MasonryItem.tsx
+++ b/src/app/components/Projects/MasonryItem.tsx
@@ -1,23 +1,22 @@
-"use client";
-import React, { useState } from "react";
-import { usePathname } from "next/navigation";
+"use client"
+import { Project } from "@/contexts/ProjectsContext"
 import {
   Box,
   Card,
-  CardMedia,
   CardContent,
   Chip,
   Typography,
   styled,
   useTheme,
-} from "@mui/material";
-import { Project } from "@/contexts/ProjectsContext";
-import { arrayRandomItem } from "nicks-web-helpers";
-import SideBarModal from "./SideBarModal";
-import MediaRenderer from "./MediaRenderer";
+} from "@mui/material"
+import { usePathname } from "next/navigation"
+import { arrayRandomItem } from "nicks-web-helpers"
+import React, { useState } from "react"
+import MediaRenderer from "./MediaRenderer"
+import SideBarModal from "./SideBarModal"
 
 interface MasonryItemProps {
-  item?: Project;
+  item?: Project
 }
 
 const StyledCard = styled(Card)(({ theme }) => ({
@@ -54,7 +53,7 @@ const StyledCard = styled(Card)(({ theme }) => ({
       transform: "none",
     },
   },
-}));
+}))
 
 const ContentSlate = styled(CardContent)(({ theme }) => ({
   position: "absolute",
@@ -69,29 +68,29 @@ const ContentSlate = styled(CardContent)(({ theme }) => ({
   transform: "translateY(100%)",
   transition: "opacity 300ms ease-in-out, transform 300ms ease-in-out",
   zIndex: 2,
-}));
+}))
 
 const TechChip = styled(Chip)(({ theme }) => ({
   margin: theme.spacing(0.5),
   backgroundColor: theme.palette.grey[600],
   color: theme.palette.common.white,
-}));
+}))
 
 const MasonryItem: React.FC<MasonryItemProps> = ({ item }) => {
-  const theme = useTheme();
-  const pathname = usePathname();
-  const [showModal, setShowModal] = useState<boolean>(false);
+  const theme = useTheme()
+  const pathname = usePathname()
+  const [showModal, setShowModal] = useState<boolean>(false)
   const [height] = useState<string>(
-    arrayRandomItem(["400px", "454px", "310px"])
-  );
+    arrayRandomItem(["400px", "454px", "310px"]),
+  )
 
   const handleCardClick = () => {
     if (pathname.includes("projects")) {
-      setShowModal(true);
+      setShowModal(true)
     } else if (item?.link) {
-      window.open(item.link, "_blank", "noopener,noreferrer");
+      window.open(item.link, "_blank", "noopener,noreferrer")
     }
-  };
+  }
 
   // TODO: on safari use an image tag with an h264 mp4 video https://developer.apple.com/documentation/webkit/delivering_video_content_for_safari#3030250
   return (
@@ -137,7 +136,7 @@ const MasonryItem: React.FC<MasonryItemProps> = ({ item }) => {
         />
       )}
     </>
-  );
-};
+  )
+}
 
-export default MasonryItem;
+export default MasonryItem

--- a/src/app/components/Projects/MasonryLayout.tsx
+++ b/src/app/components/Projects/MasonryLayout.tsx
@@ -1,7 +1,7 @@
-import React, { PropsWithChildren } from "react";
-import { Masonry } from "@mui/lab";
-import { Box, useTheme } from "@mui/material";
-import { keyframes } from "@mui/material/styles";
+import { Masonry } from "@mui/lab"
+import { Box, useTheme } from "@mui/material"
+import { keyframes } from "@mui/material/styles"
+import React, { PropsWithChildren } from "react"
 
 const fadeInUp = keyframes`
   from {
@@ -12,10 +12,10 @@ const fadeInUp = keyframes`
     marginTop: '1.5em';
     opacity: 1;
   }
-`;
+`
 
 const MasonryLayout: React.FC<PropsWithChildren<any>> = ({ children }) => {
-  const theme = useTheme();
+  const theme = useTheme()
 
   return (
     <Box
@@ -32,7 +32,7 @@ const MasonryLayout: React.FC<PropsWithChildren<any>> = ({ children }) => {
         {children}
       </Masonry>
     </Box>
-  );
-};
+  )
+}
 
-export default MasonryLayout;
+export default MasonryLayout

--- a/src/app/components/Projects/MediaRenderer.tsx
+++ b/src/app/components/Projects/MediaRenderer.tsx
@@ -1,15 +1,15 @@
-import React, { MediaHTMLAttributes } from "react";
-import { CardMedia, SxProps } from "@mui/material";
-import Image from "next/image";
-import { useBrowser } from "@/contexts/BrowserContext";
-import imgixURLBuilder from "@/utils/imageUrlBuilder";
-import { MediaType } from "@/contexts/ProjectsContext";
+import { useBrowser } from "@/contexts/BrowserContext"
+import { MediaType } from "@/contexts/ProjectsContext"
+import imgixURLBuilder from "@/utils/imageUrlBuilder"
+import { CardMedia, SxProps } from "@mui/material"
+import Image from "next/image"
+import React, { MediaHTMLAttributes } from "react"
 
 interface MediaRendererProps {
-  card?: boolean;
-  mediaUrl: string;
-  mediaAlt: string;
-  mediaType: MediaType;
+  card?: boolean
+  mediaUrl: string
+  mediaAlt: string
+  mediaType: MediaType
 }
 
 const MediaRenderer: React.FC<MediaRendererProps> = ({
@@ -18,12 +18,12 @@ const MediaRenderer: React.FC<MediaRendererProps> = ({
   mediaAlt,
   mediaType,
 }) => {
-  const { isSafari } = useBrowser();
+  const { isSafari } = useBrowser()
 
   const getModifiedUrl = (url: string) => {
-    const modifiedUrl = isSafari ? url.replace(".webm", ".mp4") : url;
-    return imgixURLBuilder(modifiedUrl);
-  };
+    const modifiedUrl = isSafari ? url.replace(".webm", ".mp4") : url
+    return imgixURLBuilder(modifiedUrl)
+  }
 
   const videoProps: MediaHTMLAttributes<HTMLVideoElement> = {
     src: getModifiedUrl(mediaUrl),
@@ -31,7 +31,7 @@ const MediaRenderer: React.FC<MediaRendererProps> = ({
     muted: true,
     playsInline: true,
     loop: true,
-  };
+  }
 
   const commonStyles: SxProps = {
     position: "absolute",
@@ -40,7 +40,7 @@ const MediaRenderer: React.FC<MediaRendererProps> = ({
     width: "100%",
     height: "100%",
     objectFit: "cover",
-  };
+  }
 
   return (
     <>
@@ -89,7 +89,7 @@ const MediaRenderer: React.FC<MediaRendererProps> = ({
         </>
       )}
     </>
-  );
-};
+  )
+}
 
-export default MediaRenderer;
+export default MediaRenderer

--- a/src/app/components/Projects/ProjectsContent.tsx
+++ b/src/app/components/Projects/ProjectsContent.tsx
@@ -1,21 +1,20 @@
-"use client";
-import React from "react";
-import { Container, Typography, Grid2 as Grid } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
-import { ProjectType, useProjectsContext } from "@/contexts/ProjectsContext";
-import MasonryLayout from "./MasonryLayout";
-import MasonryItem from "./MasonryItem";
-import FooterLink from "../FooterLink";
-import { motion } from "framer-motion";
-import { useTransitions } from "@/hooks/useTransitions";
-import CustomTabs from "../CustomTabs";
+"use client"
+import { ProjectType, useProjectsContext } from "@/contexts/ProjectsContext"
+import { useTransitions } from "@/hooks/useTransitions"
+import { Container, Grid2 as Grid, Typography } from "@mui/material"
+import { useTheme } from "@mui/material/styles"
+import { motion } from "framer-motion"
+import CustomTabs from "../CustomTabs"
+import FooterLink from "../FooterLink"
+import MasonryItem from "./MasonryItem"
+import MasonryLayout from "./MasonryLayout"
 
 const ProjectsContent = () => {
-  const theme = useTheme();
-  const { projects } = useProjectsContext();
-  const motionPropsHeading = useTransitions(0.2);
-  const motionPropsTabs = useTransitions(0.4);
-  const motionPropsFooter = useTransitions(0.6);
+  const theme = useTheme()
+  const { projects } = useProjectsContext()
+  const motionPropsHeading = useTransitions(0.2)
+  const motionPropsTabs = useTransitions(0.4)
+  const motionPropsFooter = useTransitions(0.6)
 
   const tabItems = [
     {
@@ -64,7 +63,7 @@ const ProjectsContent = () => {
         </MasonryLayout>
       ),
     },
-  ];
+  ]
 
   return (
     <>
@@ -108,7 +107,7 @@ const ProjectsContent = () => {
         </Grid>
       </Container>
     </>
-  );
-};
+  )
+}
 
-export default ProjectsContent;
+export default ProjectsContent

--- a/src/app/components/Projects/SideBarModal.tsx
+++ b/src/app/components/Projects/SideBarModal.tsx
@@ -1,29 +1,29 @@
-"use client";
-import React, { useCallback, useEffect } from "react";
+"use client"
+import { Project } from "@/contexts/ProjectsContext"
+import CloseIcon from "@mui/icons-material/Close"
+import GitHubIcon from "@mui/icons-material/GitHub"
+import LanguageIcon from "@mui/icons-material/Language"
+import OpenInNewIcon from "@mui/icons-material/OpenInNew"
 import {
+  Box,
+  Button,
+  Chip,
   Drawer,
   IconButton,
-  Typography,
-  Box,
-  Chip,
   Stack,
-  Button,
   styled,
+  Typography,
   useMediaQuery,
   useTheme,
-} from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import GitHubIcon from "@mui/icons-material/GitHub";
-import LanguageIcon from "@mui/icons-material/Language";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import CustomLink from "../CustomLink";
-import MediaRenderer from "./MediaRenderer";
-import { Project } from "@/contexts/ProjectsContext";
+} from "@mui/material"
+import React, { useCallback, useEffect } from "react"
+import CustomLink from "../CustomLink"
+import MediaRenderer from "./MediaRenderer"
 
 interface ISideBarModal {
-  show: boolean;
-  closeShow: () => void;
-  data?: Project;
+  show: boolean
+  closeShow: () => void
+  data?: Project
 }
 
 const MediaContainer = styled(Box)({
@@ -32,14 +32,14 @@ const MediaContainer = styled(Box)({
   overflow: "hidden",
   height: "300px",
   borderRadius: 11,
-});
+})
 
 const TechnologyChip = styled(Chip)(({ theme }) => ({
   margin: theme.spacing(0.5),
   backgroundColor: theme.palette.grey.A400,
   color: theme.palette.text.primary,
   fontWeight: "bold",
-}));
+}))
 
 const OpenProjectButton = styled(Button)(({ theme }) => ({
   position: "sticky",
@@ -47,36 +47,36 @@ const OpenProjectButton = styled(Button)(({ theme }) => ({
   width: "100%",
   marginTop: theme.spacing(2),
   padding: theme.spacing(2),
-}));
+}))
 
 const SideBarModal: React.FC<ISideBarModal> = ({
   show = false,
   closeShow = () => {},
   data,
 }) => {
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
-  const isLargeScreen = useMediaQuery(theme.breakpoints.up("lg"));
+  const theme = useTheme()
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"))
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up("lg"))
 
   const handleKeyPress = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        closeShow();
+        closeShow()
       }
     },
-    [closeShow]
-  );
+    [closeShow],
+  )
 
   useEffect(() => {
-    window.addEventListener("keydown", handleKeyPress);
+    window.addEventListener("keydown", handleKeyPress)
     return () => {
-      window.removeEventListener("keydown", handleKeyPress);
-    };
-  }, [handleKeyPress]);
+      window.removeEventListener("keydown", handleKeyPress)
+    }
+  }, [handleKeyPress])
 
-  const drawerWidth = isSmallScreen ? "100%" : isLargeScreen ? 600 : 500;
+  const drawerWidth = isSmallScreen ? "100%" : isLargeScreen ? 600 : 500
 
-  if (!data) return null;
+  if (!data) return null
 
   return (
     <Drawer
@@ -115,8 +115,8 @@ const SideBarModal: React.FC<ISideBarModal> = ({
           <CustomLink
             href="#"
             onClick={(e) => {
-              e.preventDefault();
-              closeShow();
+              e.preventDefault()
+              closeShow()
             }}
             underline="hover"
           >
@@ -280,7 +280,7 @@ const SideBarModal: React.FC<ISideBarModal> = ({
         </CustomLink>
       </Box>
     </Drawer>
-  );
-};
+  )
+}
 
-export default SideBarModal;
+export default SideBarModal

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,6 @@
-import type { Metadata } from "next";
-import NavBar from "../components/Navbar";
-import ContactContent from "../components/Contact/ContactContent";
+import type { Metadata } from "next"
+import ContactContent from "../components/Contact/ContactContent"
+import NavBar from "../components/Navbar"
 
 export const metadata: Metadata = {
   title: "Contact Me | Nick Brady",
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "https://dev.nickbrady.dev/contact",
   },
-};
+}
 
 export default function Contact() {
   return (
@@ -18,5 +18,5 @@ export default function Contact() {
       <NavBar />
       <ContactContent />
     </>
-  );
+  )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
-import type { Metadata } from "next";
-import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
-import { ThemeProvider, CssBaseline } from "@mui/material";
-import { Analytics } from "@vercel/analytics/react";
-import mainTheme from "@/styles/theme";
+import mainTheme from "@/styles/theme"
+import { CssBaseline, ThemeProvider } from "@mui/material"
+import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter"
+import { Analytics } from "@vercel/analytics/react"
+import type { Metadata } from "next"
 
 export const metadata: Metadata = {
   title: {
@@ -76,12 +76,12 @@ export const metadata: Metadata = {
     creatorId: "1829973002295132160",
   },
   category: "technology",
-};
+}
 
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
   return (
     <html lang="en">
@@ -95,5 +95,5 @@ export default function RootLayout({
         </AppRouterCacheProvider>
       </body>
     </html>
-  );
+  )
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,8 @@
-"use client";
-import React from "react";
+"use client"
+import { labrada } from "@/styles/additionalFonts"
+import { subtleBounce } from "@/styles/keyframes"
+import HomeIcon from "@mui/icons-material/Home"
+import SentimentVeryDissatisfiedIcon from "@mui/icons-material/SentimentVeryDissatisfied"
 import {
   Box,
   Button,
@@ -7,16 +10,13 @@ import {
   Stack,
   Typography,
   useTheme,
-} from "@mui/material";
-import HomeIcon from "@mui/icons-material/Home";
-import SentimentVeryDissatisfiedIcon from "@mui/icons-material/SentimentVeryDissatisfied";
-import Image from "next/image";
-import { subtleBounce } from "@/styles/keyframes";
-import { labrada } from "@/styles/additionalFonts";
-import CustomLink from "./components/CustomLink";
+} from "@mui/material"
+import Image from "next/image"
+import React from "react"
+import CustomLink from "./components/CustomLink"
 
 export default function NotFound(): React.JSX.Element {
-  const theme = useTheme();
+  const theme = useTheme()
 
   return (
     <Container
@@ -98,5 +98,5 @@ export default function NotFound(): React.JSX.Element {
         </Button>
       </CustomLink>
     </Container>
-  );
+  )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
-import type { Metadata } from "next";
-import { PageWrapper } from "./components/Layout";
-import NavBar from "./components/Navbar";
-import IntroPageContent from "./components/LandingPage/IntroContent";
+import type { Metadata } from "next"
+import IntroPageContent from "./components/LandingPage/IntroContent"
+import { PageWrapper } from "./components/Layout"
+import NavBar from "./components/Navbar"
 
 export const metadata: Metadata = {
   title: "Home | Nick Brady",
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "https://dev.nickbrady.dev",
   },
-};
+}
 
 export default function Home() {
   return (
@@ -21,5 +21,5 @@ export default function Home() {
         <IntroPageContent />
       </PageWrapper>
     </>
-  );
+  )
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,8 +1,8 @@
-import type { Metadata } from "next";
-import NavBar from "../components/Navbar";
-import { ProjectsProvider } from "@/contexts/ProjectsContext";
-import { BrowserProvider } from "@/contexts/BrowserContext";
-import ProjectsContent from "../components/Projects/ProjectsContent";
+import { BrowserProvider } from "@/contexts/BrowserContext"
+import { ProjectsProvider } from "@/contexts/ProjectsContext"
+import type { Metadata } from "next"
+import NavBar from "../components/Navbar"
+import ProjectsContent from "../components/Projects/ProjectsContent"
 
 export const metadata: Metadata = {
   title: "Projects | Nick Brady",
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "https://dev.nickbrady.dev/projects",
   },
-};
+}
 
 export default function Projects() {
   return (
@@ -24,5 +24,5 @@ export default function Projects() {
         </BrowserProvider>
       </ProjectsProvider>
     </>
-  );
+  )
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,4 @@
-import type { MetadataRoute } from "next";
+import type { MetadataRoute } from "next"
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
@@ -8,5 +8,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "daily", // set to hourly for now
       priority: 1,
     },
-  ];
+  ]
 }

--- a/src/contexts/AboutContext.tsx
+++ b/src/contexts/AboutContext.tsx
@@ -1,47 +1,45 @@
-"use client";
+"use client"
 
-import React, { createContext, useContext, ReactNode } from "react";
-import GitHubIcon from "@mui/icons-material/GitHub";
-import PublicIcon from "@mui/icons-material/Public";
-import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
-import LibraryMusicIcon from "@mui/icons-material/LibraryMusic";
-import PhotoCameraBackIcon from "@mui/icons-material/PhotoCameraBack";
-import CopyrightIcon from "@mui/icons-material/Copyright";
+import GitHubIcon from "@mui/icons-material/GitHub"
+import LibraryMusicIcon from "@mui/icons-material/LibraryMusic"
+import PhotoCameraBackIcon from "@mui/icons-material/PhotoCameraBack"
+import PublicIcon from "@mui/icons-material/Public"
+import React, { createContext, ReactNode, useContext } from "react"
 
 // Define the base timeline data interface with common properties
 export interface TimelineItemType {
-  title: string;
-  subtitle?: string;
-  icon?: ReactNode;
-  description: string;
-  link: string;
-  linkText: string;
-  ariaLabel: string;
+  title: string
+  subtitle?: string
+  icon?: ReactNode
+  description: string
+  link: string
+  linkText: string
+  ariaLabel: string
 }
 
 // Define the context data type that combines all items
 type AboutContextType = {
-  aboutMeData: TimelineItemType[];
-  myPlaylistData: TimelineItemType[];
-  myPhotographyData: TimelineItemType[];
-};
+  aboutMeData: TimelineItemType[]
+  myPlaylistData: TimelineItemType[]
+  myPhotographyData: TimelineItemType[]
+}
 
 export const AboutContext = createContext<AboutContextType | undefined>(
-  undefined
-);
+  undefined,
+)
 
 export const useAboutContext = () => {
-  const context = useContext(AboutContext);
+  const context = useContext(AboutContext)
   if (context === undefined) {
-    throw new Error("useAboutContext must be used within an AboutProvider");
+    throw new Error("useAboutContext must be used within an AboutProvider")
   }
-  return context;
-};
+  return context
+}
 
 export default function AboutProvider({
   children,
 }: {
-  children: React.ReactNode;
+  children: React.ReactNode
 }) {
   const aboutData: AboutContextType = {
     aboutMeData: [
@@ -137,9 +135,9 @@ export default function AboutProvider({
         ariaLabel: "Go to Nick's photography collection page",
       },
     ],
-  };
+  }
 
   return (
     <AboutContext.Provider value={aboutData}>{children}</AboutContext.Provider>
-  );
+  )
 }

--- a/src/contexts/BrowserContext.tsx
+++ b/src/contexts/BrowserContext.tsx
@@ -1,42 +1,42 @@
-"use client";
-import React, { createContext, useContext, useEffect, useState } from "react";
+"use client"
+import React, { createContext, useContext, useEffect, useState } from "react"
 
 interface BrowserContextType {
-  isSafari: boolean;
+  isSafari: boolean
 }
 
-const BrowserContext = createContext<BrowserContextType | undefined>(undefined);
+const BrowserContext = createContext<BrowserContextType | undefined>(undefined)
 
 interface BrowserContextProps {
-  children: React.ReactNode;
+  children: React.ReactNode
 }
 
 export const BrowserProvider: React.FC<BrowserContextProps> = ({
   children,
 }) => {
-  const [isSafari, setIsSafari] = useState<boolean>(false);
+  const [isSafari, setIsSafari] = useState<boolean>(false)
 
   useEffect(() => {
-    const userAgent = window.navigator.userAgent;
+    const userAgent = window.navigator.userAgent
     const isSafariBrowser =
       /^((?!chrome|android).)*safari/i.test(userAgent) &&
-      !userAgent.includes("CriOS");
-    setIsSafari(isSafariBrowser);
-  }, []);
+      !userAgent.includes("CriOS")
+    setIsSafari(isSafariBrowser)
+  }, [])
 
   return (
     <BrowserContext.Provider value={{ isSafari }}>
       {children}
     </BrowserContext.Provider>
-  );
-};
+  )
+}
 
 // Hook to use the context
 export const useBrowser = (): BrowserContextType => {
-  const context = useContext(BrowserContext);
+  const context = useContext(BrowserContext)
   if (context === undefined) {
-    throw new Error("useBrowser must be used within a BrowserProvider");
+    throw new Error("useBrowser must be used within a BrowserProvider")
   }
 
-  return context;
-};
+  return context
+}

--- a/src/contexts/ProjectsContext.tsx
+++ b/src/contexts/ProjectsContext.tsx
@@ -1,12 +1,12 @@
-"use client";
+"use client"
 import React, {
   createContext,
-  useContext,
-  useState,
-  useEffect,
   ReactNode,
-} from "react";
-import projectsData from "../data/projects.json";
+  useContext,
+  useEffect,
+  useState,
+} from "react"
+import projectsData from "../data/projects.json"
 
 // Define types
 export enum ProjectType {
@@ -16,61 +16,61 @@ export enum ProjectType {
   Others = "others",
 }
 
-export type MediaType = "video" | "image";
+export type MediaType = "video" | "image"
 
 export interface Project {
-  title: string;
-  description: string;
-  about: string;
-  link?: string;
-  mediaUrl: string;
-  mediaAlt: string;
-  mediaType: MediaType;
-  github: string;
-  type: ProjectType[];
-  technologies: string[];
+  title: string
+  description: string
+  about: string
+  link?: string
+  mediaUrl: string
+  mediaAlt: string
+  mediaType: MediaType
+  github: string
+  type: ProjectType[]
+  technologies: string[]
 }
 
 interface ProjectsContextType {
-  projects: Project[];
-  getProjectsByType: (type: ProjectType) => Project[];
+  projects: Project[]
+  getProjectsByType: (type: ProjectType) => Project[]
 }
 
 // Create the context
 const ProjectsContext = createContext<ProjectsContextType | undefined>(
-  undefined
-);
+  undefined,
+)
 
 // Helper function to convert string to ProjectType
 // TODO: add other types here
 const stringToProjectType = (str: string): ProjectType => {
   switch (str) {
     case "project":
-      return ProjectType.Project;
+      return ProjectType.Project
     case "open-source":
-      return ProjectType.OpenSource;
+      return ProjectType.OpenSource
     case "tools":
-      return ProjectType.Tools;
+      return ProjectType.Tools
     case "others":
-      return ProjectType.Others;
+      return ProjectType.Others
     default:
-      throw new Error(`Invalid project type: ${str}`);
+      throw new Error(`Invalid project type: ${str}`)
   }
-};
+}
 
 // Helper function to parse mediaType
 const parseMediaType = (mediaType: string): MediaType => {
   if (mediaType === "video" || mediaType === "image") {
-    return mediaType;
+    return mediaType
   }
-  throw new Error(`Invalid media type: ${mediaType}`);
-};
+  throw new Error(`Invalid media type: ${mediaType}`)
+}
 
 // Create the provider component
 export const ProjectsProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
-  const [projects, setProjects] = useState<Project[]>([]);
+  const [projects, setProjects] = useState<Project[]>([])
 
   useEffect(() => {
     // convert and set projects from our imported JSON data
@@ -78,33 +78,33 @@ export const ProjectsProvider: React.FC<{ children: ReactNode }> = ({
       ...project,
       type: project.type.map(stringToProjectType),
       mediaType: parseMediaType(project.mediaType),
-    }));
-    setProjects(parsedProjects);
-  }, []);
+    }))
+    setProjects(parsedProjects)
+  }, [])
 
   const getProjectsByType = (type: ProjectType): Project[] => {
-    return projects.filter((project) => project.type.includes(type));
-  };
+    return projects.filter((project) => project.type.includes(type))
+  }
 
   const value: ProjectsContextType = {
     projects,
     getProjectsByType,
-  };
+  }
 
   return (
     <ProjectsContext.Provider value={value}>
       {children}
     </ProjectsContext.Provider>
-  );
-};
+  )
+}
 
 // Custom hook to use the projects context
 export const useProjectsContext = (): ProjectsContextType => {
-  const context = useContext(ProjectsContext);
+  const context = useContext(ProjectsContext)
   if (context === undefined) {
     throw new Error(
-      "useProjectsContext must be used within a Projects Provider"
-    );
+      "useProjectsContext must be used within a Projects Provider",
+    )
   }
-  return context;
-};
+  return context
+}

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,30 +1,30 @@
-"use client";
-import React, { useState, useEffect } from "react";
-import { useRouter } from "next/router";
+"use client"
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react"
 
 const useActiveSection = () => {
-  const [activeSection, setActiveSection] = useState<string>("top");
-  const router = useRouter();
+  const [activeSection, setActiveSection] = useState<string>("top")
+  const router = useRouter()
 
   useEffect(() => {
     const handleRouteChange = (url: string) => {
-      const hash = url.split("#")[1];
-      setActiveSection(hash || "top");
-    };
+      const hash = url.split("#")[1]
+      setActiveSection(hash || "top")
+    }
 
     // Set initial active section
-    handleRouteChange(router.asPath);
+    handleRouteChange(router.asPath)
 
     // Listen for hash changes
-    router.events.on("hashChangeComplete", handleRouteChange);
+    router.events.on("hashChangeComplete", handleRouteChange)
 
     // Cleanup listener on unmount
     return () => {
-      router.events.off("hashChangeComplete", handleRouteChange);
-    };
-  }, [router]);
+      router.events.off("hashChangeComplete", handleRouteChange)
+    }
+  }, [router])
 
-  return activeSection;
-};
+  return activeSection
+}
 
-export default useActiveSection;
+export default useActiveSection

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,16 +1,16 @@
-import { useState, useEffect } from "react";
-import { useTheme, useMediaQuery } from "@mui/material";
+import { useMediaQuery, useTheme } from "@mui/material"
+import { useEffect, useState } from "react"
 
 const useIsMobile = () => {
-  const theme = useTheme();
-  const isMobileQuery = useMediaQuery(theme.breakpoints.down("md"));
-  const [isMobile, setIsMobile] = useState<boolean>(isMobileQuery);
+  const theme = useTheme()
+  const isMobileQuery = useMediaQuery(theme.breakpoints.down("md"))
+  const [isMobile, setIsMobile] = useState<boolean>(isMobileQuery)
 
   useEffect(() => {
-    setIsMobile(isMobileQuery);
-  }, [isMobileQuery]);
+    setIsMobile(isMobileQuery)
+  }, [isMobileQuery])
 
-  return isMobile;
-};
+  return isMobile
+}
 
-export default useIsMobile;
+export default useIsMobile

--- a/src/hooks/useTransitions.ts
+++ b/src/hooks/useTransitions.ts
@@ -1,25 +1,25 @@
-import { useMemo } from "react";
-import { useReducedMotion, MotionProps } from "framer-motion";
+import { MotionProps, useReducedMotion } from "framer-motion"
+import { useMemo } from "react"
 
 // define the two variant sets once
 const defaultVariants = {
   initial: { opacity: 0, y: 20, scale: 0.98 },
   animate: { opacity: 1, y: 0, scale: 1 },
   exit: { opacity: 0, y: 20, scale: 0.98 },
-} as const;
+} as const
 
 const reducedVariants = {
   initial: { opacity: 1, y: 0, scale: 1 },
   animate: { opacity: 1, y: 0, scale: 1 },
   exit: { opacity: 1, y: 0, scale: 1 },
-} as const;
+} as const
 
 /**
  * A hook that returns { transition, initial, animate, exit }
  * automatically adjusting for prefers-reduced-motion.
  */
 export const useTransitions = (delay: number = 0): MotionProps => {
-  const shouldReduceMotion = useReducedMotion();
+  const shouldReduceMotion = useReducedMotion()
 
   // memoize the transition object
   const transition = useMemo(
@@ -27,12 +27,12 @@ export const useTransitions = (delay: number = 0): MotionProps => {
       duration: shouldReduceMotion ? 0 : 0.5,
       delay,
     }),
-    [delay, shouldReduceMotion]
-  );
+    [delay, shouldReduceMotion],
+  )
 
   // pick the correct variants
-  const variants = shouldReduceMotion ? reducedVariants : defaultVariants;
+  const variants = shouldReduceMotion ? reducedVariants : defaultVariants
 
   // return in the shape of MotionProps
-  return { transition, ...variants };
-};
+  return { transition, ...variants }
+}

--- a/src/styles/additionalFonts.ts
+++ b/src/styles/additionalFonts.ts
@@ -1,7 +1,7 @@
-import { Labrada } from "next/font/google";
+import { Labrada } from "next/font/google"
 
 export const labrada = Labrada({
   subsets: ["latin"],
   weight: ["300", "400", "500", "600", "700"],
   display: "swap",
-});
+})

--- a/src/styles/keyframes.ts
+++ b/src/styles/keyframes.ts
@@ -1,4 +1,4 @@
-import { keyframes } from "@mui/material/styles";
+import { keyframes } from "@mui/material/styles"
 
 export const noiseAnim2 = keyframes`
       0% {
@@ -65,7 +65,7 @@ export const noiseAnim2 = keyframes`
         clip-path: inset(1% 0 81% 0);
       }
     }
-`;
+`
 
 export const noiseAnim = keyframes`
       0% {
@@ -132,7 +132,7 @@ export const noiseAnim = keyframes`
         clip-path: inset(95% 0 2% 0);
       }
     }
-`;
+`
 
 export const arrowBounce = keyframes`
       from {
@@ -141,7 +141,7 @@ export const arrowBounce = keyframes`
       to {
         transform: translateX(2rem);
       }
-`;
+`
 
 export const underlineAnimation = keyframes`
   0% {
@@ -150,7 +150,7 @@ export const underlineAnimation = keyframes`
   100% {
     transform: scaleX(1);
   }
-`;
+`
 
 export const subtleBounce = keyframes`
   0%, 100% {
@@ -159,4 +159,4 @@ export const subtleBounce = keyframes`
   50% {
     transform: translateY(-10px);
   }
-`;
+`

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,18 +1,18 @@
-"use client";
-import { createTheme, responsiveFontSizes } from "@mui/material/styles";
-import { Lato, Lora } from "next/font/google";
+"use client"
+import { createTheme, responsiveFontSizes } from "@mui/material/styles"
+import { Lato, Lora } from "next/font/google"
 
 const lora = Lora({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
   display: "swap",
-});
+})
 
 const lato = Lato({
   subsets: ["latin"],
   weight: ["400", "700", "100", "300", "900"],
   display: "swap",
-});
+})
 
 const mainTheme = responsiveFontSizes(
   createTheme({
@@ -33,7 +33,7 @@ const mainTheme = responsiveFontSizes(
       h5: { fontFamily: lora.style.fontFamily },
       h6: { fontFamily: lora.style.fontFamily },
     },
-  })
-);
+  }),
+)
 
-export default mainTheme;
+export default mainTheme

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -1,27 +1,27 @@
-import { Theme, ThemeOptions } from "@mui/material/styles";
+import { Theme, ThemeOptions } from "@mui/material/styles"
 
 interface CustomPalette {
   sidebar: {
-    backgroundColor: string;
-    textColor: string;
-    hoverTextColor: string;
-    hoverBackgroundColor: string;
-    hoverIconColor: string;
-    dividerColor: string;
-  };
+    backgroundColor: string
+    textColor: string
+    hoverTextColor: string
+    hoverBackgroundColor: string
+    hoverIconColor: string
+    dividerColor: string
+  }
 }
 
 interface CustomTheme extends Theme {
-  palette: Theme["palette"] & CustomPalette;
+  palette: Theme["palette"] & CustomPalette
 }
 
 interface CustomThemeOptions extends ThemeOptions {
-  palette?: Partial<CustomTheme["palette"]>;
+  palette?: Partial<CustomTheme["palette"]>
 }
 
 declare module "@mui/material/styles" {
   interface Palette extends CustomTheme {}
   interface PaletteOptions extends Partial<CustomPalette> {}
 
-  export function createTheme(options?: CustomThemeOptions): CustomTheme;
+  export function createTheme(options?: CustomThemeOptions): CustomTheme
 }

--- a/src/utils/imageUrlBuilder.ts
+++ b/src/utils/imageUrlBuilder.ts
@@ -1,5 +1,5 @@
 export default function imgixURLBuilder(src: string, options?: {}) {
-  const url = new URL(`https://personal-portfolio-products.imgix.net/${src}`);
+  const url = new URL(`https://personal-portfolio-products.imgix.net/${src}`)
 
-  return url.href;
+  return url.href
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -22,9 +18,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
     "target": "ES2017"
   },
@@ -35,7 +29,5 @@
     ".next/types/**/*.ts",
     "@/types/theme.d.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This squash-merge consolidates our transition implementation by fully
removing the legacy `getTransitions` utility and adopting the
`useTransitions` hook in all affected components:

- Components updated: AboutContent, ContactContent, IntroContent,
  IntroductionText, ProjectsContent  
- All `<motion.div>` spreads now use memoized `motionProps*` from the
  hook  
- Deprecated `src/utils/transitions.ts` has been deleted  
