### PR TITLE
chore(mui): migrate deprecated MUI APIs via @mui/codemod

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -189,9 +189,11 @@ const NavBar: React.FC<NavBarProps> = () => {
         >
           <ListItemText
             primary={text}
-            primaryTypographyProps={{
-              variant: "h6",
-              sx: { textAlign: "center" },
+            slotProps={{
+              primary: {
+                variant: "h6",
+                sx: { textAlign: "center" },
+              },
             }}
           />
         </ListItemButton>
@@ -291,13 +293,15 @@ const NavBar: React.FC<NavBarProps> = () => {
           ModalProps={{
             keepMounted: true,
           }}
-          PaperProps={{
-            sx: { width: "100vw", height: "100vh" },
-          }}
           sx={{
             sm: "block",
             md: "none",
             "& .MuiDrawer-paper": { boxSizing: "border-box" },
+          }}
+          slotProps={{
+            paper: {
+              sx: { width: "100vw", height: "100vh" },
+            },
           }}
         >
           {drawer}

--- a/src/app/components/Projects/SideBarModal.tsx
+++ b/src/app/components/Projects/SideBarModal.tsx
@@ -85,12 +85,14 @@ const SideBarModal: React.FC<ISideBarModal> = ({
       onClose={closeShow}
       aria-labelledby="product-modal-title"
       aria-describedby="product-modal-description"
-      PaperProps={{
-        style: {
-          padding: "1.5rem",
-        },
-        sx: {
-          width: drawerWidth,
+      slotProps={{
+        paper: {
+          style: {
+            padding: "1.5rem",
+          },
+          sx: {
+            width: drawerWidth,
+          },
         },
       }}
     >


### PR DESCRIPTION
## Summary
This PR runs the `@mui/codemod@latest deprecations/all` to automatically migrate all deprecated Material-UI (MUI) APIs to their current recommended usage. It replaces legacy props such as `primaryTypographyProps` and `PaperProps` with the new `slotProps` API across the Navbar and SideBarModal components in the portfolio.

## Changes
- **Navbar.tsx**
  - Replaced `primaryTypographyProps` with `slotProps.primary` on `<ListItemText>`  
  - Converted `PaperProps` overrides to `slotProps.paper` on `<Drawer>`  
  - Adjusted closing parentheses style per codemod output  
- **SideBarModal.tsx**
  - Migrated `PaperProps` to `slotProps.paper` with both `style` and `sx` overrides on `<Drawer>`  

## Motivation
Keeping the portfolio up-to-date with the latest MUI patterns prevents future breakages and aligns with the official MUI migration guide. Automating this via codemod ensures consistency and reduces manual errors.
