### PR TITLE
chore: cleanup React imports and remove unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
     "framer-motion": "^12.16.0",
     "next": "latest",
     "nicks-web-helpers": "^1.1.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-imgix": "^9.10.0"
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@types/node": "^22.15.30",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,12 +47,6 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
-      react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
-      react-imgix:
-        specifier: ^9.10.0
-        version: 9.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@types/node':
         specifier: ^22.15.30
@@ -379,9 +373,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@imgix/js-core@3.8.0':
-    resolution: {integrity: sha512-kvLmsODQq7W17UuhDIffimlKN+AUTgtQCgD8kpPN0gglvaqR1VZKXl4gB5eAUXgrwNgi5hRDl5XYAMFRPIUztw==}
 
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
@@ -965,9 +956,6 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  charenc@0.0.2:
-    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
-
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -1002,9 +990,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  crypt@0.0.2:
-    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1319,9 +1304,6 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-node-dimensions@1.2.1:
-    resolution: {integrity: sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ==}
-
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
@@ -1432,9 +1414,6 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
-  is-buffer@1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
-
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
 
@@ -1532,9 +1511,6 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
-  js-base64@3.7.7:
-    resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1598,9 +1574,6 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  md5@2.3.0:
-    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1794,23 +1767,11 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-imgix@9.10.0:
-    resolution: {integrity: sha512-JImyil3EJEkxLfHrmd7D9gBcFjnnqm2rTMA1HFTG3G4s6BJvrd2hX1giZKp1pcWLGkf7hPy5COKoN3e6YFSJOA==}
-    peerDependencies:
-      react: 15.x || 16.x || 17.x || 18.x
-      react-dom: 15.x || 16.x || 17.x || 18.x
-
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@19.1.0:
     resolution: {integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==}
-
-  react-measure@2.5.2:
-    resolution: {integrity: sha512-M+rpbTLWJ3FD6FXvYV6YEGvQ5tMayQ3fGrZhRPHrE9bVlBYfDCLuDcgNttYfk8IqfOI03jz6cbpqMRTUclQnaA==}
-    peerDependencies:
-      react: '>0.13.0'
-      react-dom: '>0.13.0'
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -1829,9 +1790,6 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
-
-  resize-observer-polyfill@1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1891,9 +1849,6 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
-
-  shallowequal@1.1.0:
-    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   sharp@0.34.2:
     resolution: {integrity: sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==}
@@ -2045,9 +2000,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.6.1:
-    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
-
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -2060,9 +2012,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  warning@4.0.3:
-    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2406,12 +2355,6 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.2':
     optional: true
-
-  '@imgix/js-core@3.8.0':
-    dependencies:
-      js-base64: 3.7.7
-      md5: 2.3.0
-      ufo: 1.6.1
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -2969,8 +2912,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  charenc@0.0.2: {}
-
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
@@ -3010,8 +2951,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  crypt@0.0.2: {}
 
   csstype@3.1.3: {}
 
@@ -3485,8 +3424,6 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-node-dimensions@1.2.1: {}
-
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
@@ -3594,8 +3531,6 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  is-buffer@1.1.6: {}
-
   is-bun-module@2.0.0:
     dependencies:
       semver: 7.7.2
@@ -3697,8 +3632,6 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
-  js-base64@3.7.7: {}
-
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -3754,12 +3687,6 @@ snapshots:
       js-tokens: 4.0.0
 
   math-intrinsics@1.1.0: {}
-
-  md5@2.3.0:
-    dependencies:
-      charenc: 0.0.2
-      crypt: 0.0.2
-      is-buffer: 1.1.6
 
   merge2@1.4.1: {}
 
@@ -3944,28 +3871,9 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-imgix@9.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@imgix/js-core': 3.8.0
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-measure: 2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      shallowequal: 1.1.0
-      warning: 4.0.3
-
   react-is@16.13.1: {}
 
   react-is@19.1.0: {}
-
-  react-measure@2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.27.6
-      get-node-dimensions: 1.2.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      resize-observer-polyfill: 1.5.1
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -3999,8 +3907,6 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
-
-  resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -4072,8 +3978,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
-
-  shallowequal@1.1.0: {}
 
   sharp@0.34.2:
     dependencies:
@@ -4284,8 +4188,6 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  ufo@1.6.1: {}
-
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -4320,10 +4222,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  warning@4.0.3:
-    dependencies:
-      loose-envify: 1.4.0
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/components/AboutMe/TimelineSection.tsx
+++ b/src/app/components/AboutMe/TimelineSection.tsx
@@ -10,7 +10,6 @@ import {
 } from "@mui/lab"
 import { Box, Typography } from "@mui/material"
 import { useTheme } from "@mui/material/styles"
-import React from "react"
 import CustomLink from "../CustomLink"
 
 type TimelineSectionProps = {

--- a/src/app/components/Contact/ContactContent.tsx
+++ b/src/app/components/Contact/ContactContent.tsx
@@ -16,7 +16,7 @@ import {
   useTheme,
 } from "@mui/material"
 import { motion } from "framer-motion"
-import React, { ChangeEvent, FormEvent, useState } from "react"
+import { ChangeEvent, FormEvent, useState } from "react"
 import FooterLink from "../FooterLink"
 
 interface FormData {

--- a/src/app/components/CustomLink.tsx
+++ b/src/app/components/CustomLink.tsx
@@ -1,6 +1,5 @@
 import { Link, LinkProps } from "@mui/material"
 import NextLink from "next/link"
-import React from "react"
 
 interface CustomLinkProps extends Omit<LinkProps, "component"> {
   href: string

--- a/src/app/components/CustomTabs.tsx
+++ b/src/app/components/CustomTabs.tsx
@@ -1,7 +1,7 @@
 import { TabContext, TabList, TabPanel } from "@mui/lab"
 import { Box, Tab } from "@mui/material"
 import { styled } from "@mui/material/styles"
-import React, { useState } from "react"
+import { useState } from "react"
 
 const StyledTab = styled(Tab)(({ theme }) => ({
   backgroundColor: "transparent",

--- a/src/app/components/FooterLink.tsx
+++ b/src/app/components/FooterLink.tsx
@@ -17,7 +17,6 @@ import {
 } from "@mui/material"
 import { styled } from "@mui/material/styles"
 import NextLink from "next/link"
-import React from "react"
 import CustomLink from "./CustomLink"
 
 interface IFooterLink {

--- a/src/app/components/LandingPage/AnimatedTitle.tsx
+++ b/src/app/components/LandingPage/AnimatedTitle.tsx
@@ -1,7 +1,6 @@
 import { noiseAnim, noiseAnim2 } from "@/styles/keyframes"
 import { Box, Typography } from "@mui/material"
 import { useTheme } from "@mui/material/styles"
-import React from "react"
 
 const AnimatedTitle: React.FC = () => {
   const theme = useTheme()

--- a/src/app/components/LandingPage/IntroContent.tsx
+++ b/src/app/components/LandingPage/IntroContent.tsx
@@ -2,7 +2,6 @@
 import { useTransitions } from "@/hooks/useTransitions"
 import { Box, useTheme } from "@mui/material"
 import { motion } from "framer-motion"
-import React from "react"
 import FooterLink from "../FooterLink"
 import AnimatedTitle from "./AnimatedTitle"
 import IntroductionText from "./IntroductionText"

--- a/src/app/components/LandingPage/IntroductionText.tsx
+++ b/src/app/components/LandingPage/IntroductionText.tsx
@@ -1,7 +1,6 @@
 import { Typography } from "@mui/material"
 import { useTheme } from "@mui/material/styles"
 import { motion } from "framer-motion"
-import React from "react"
 import CustomLink from "../CustomLink"
 
 import { useTransitions } from "@/hooks/useTransitions"

--- a/src/app/components/Layout.tsx
+++ b/src/app/components/Layout.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { Box, Container, Grid2 as Grid, useTheme } from "@mui/material"
-import React, { PropsWithChildren } from "react"
+import { PropsWithChildren } from "react"
 import NavBar from "./Navbar"
 
 interface LayoutProps {

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -23,7 +23,7 @@ import { styled } from "@mui/material/styles"
 import Image from "next/image"
 import NextLink from "next/link"
 import { usePathname } from "next/navigation"
-import React, { useState } from "react"
+import { useState } from "react"
 
 const StyledAppBar = styled(AppBar)<AppBarProps>(({ theme }) => ({
   background: "transparent",

--- a/src/app/components/Projects/MasonryItem.tsx
+++ b/src/app/components/Projects/MasonryItem.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material"
 import { usePathname } from "next/navigation"
 import { arrayRandomItem } from "nicks-web-helpers"
-import React, { useState } from "react"
+import { useState } from "react"
 import MediaRenderer from "./MediaRenderer"
 import SideBarModal from "./SideBarModal"
 

--- a/src/app/components/Projects/MasonryLayout.tsx
+++ b/src/app/components/Projects/MasonryLayout.tsx
@@ -1,7 +1,7 @@
 import { Masonry } from "@mui/lab"
 import { Box, useTheme } from "@mui/material"
 import { keyframes } from "@mui/material/styles"
-import React, { PropsWithChildren } from "react"
+import { PropsWithChildren } from "react"
 
 const fadeInUp = keyframes`
   from {

--- a/src/app/components/Projects/MediaRenderer.tsx
+++ b/src/app/components/Projects/MediaRenderer.tsx
@@ -3,7 +3,7 @@ import { MediaType } from "@/contexts/ProjectsContext"
 import imgixURLBuilder from "@/utils/imageUrlBuilder"
 import { CardMedia, SxProps } from "@mui/material"
 import Image from "next/image"
-import React, { MediaHTMLAttributes } from "react"
+import { MediaHTMLAttributes } from "react"
 
 interface MediaRendererProps {
   card?: boolean

--- a/src/app/components/Projects/SideBarModal.tsx
+++ b/src/app/components/Projects/SideBarModal.tsx
@@ -16,7 +16,7 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material"
-import React, { useCallback, useEffect } from "react"
+import { useCallback, useEffect } from "react"
 import CustomLink from "../CustomLink"
 import MediaRenderer from "./MediaRenderer"
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -12,7 +12,6 @@ import {
   useTheme,
 } from "@mui/material"
 import Image from "next/image"
-import React from "react"
 import CustomLink from "./components/CustomLink"
 
 export default function NotFound(): React.JSX.Element {

--- a/src/contexts/AboutContext.tsx
+++ b/src/contexts/AboutContext.tsx
@@ -4,7 +4,7 @@ import GitHubIcon from "@mui/icons-material/GitHub"
 import LibraryMusicIcon from "@mui/icons-material/LibraryMusic"
 import PhotoCameraBackIcon from "@mui/icons-material/PhotoCameraBack"
 import PublicIcon from "@mui/icons-material/Public"
-import React, { createContext, ReactNode, useContext } from "react"
+import { createContext, ReactNode, useContext } from "react"
 
 // Define the base timeline data interface with common properties
 export interface TimelineItemType {

--- a/src/contexts/BrowserContext.tsx
+++ b/src/contexts/BrowserContext.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { createContext, useContext, useEffect, useState } from "react"
+import { createContext, useContext, useEffect, useState } from "react"
 
 interface BrowserContextType {
   isSafari: boolean

--- a/src/contexts/ProjectsContext.tsx
+++ b/src/contexts/ProjectsContext.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, {
+import {
   createContext,
   ReactNode,
   useContext,


### PR DESCRIPTION
## Summary

This pull request cleans up the codebase by removing redundant React imports in component files (thanks to React 17+’s new JSX transform) and removing two unused dependencies (`react-dom` and `react-imgix`) from the project.

## Changes

- **refactor(components):**  
  - Removed `import React` statements from various `.tsx` component files where React is not explicitly used.  
  - This leverages the new JSX transform in React 17+, which no longer requires React to be in scope for JSX.

- **chore(deps):**  
  - Removed `react-dom` and `react-imgix` from `dependencies` in `package.json`.  
  - Updated `pnpm-lock.yaml` to drop entries related to those packages.

## Commits

- `43f8901` – refactor(components): remove redundant React imports  
- `cf2e4ce` – chore(deps): remove unused deps

## Motivation

- **Reduce bundle size** by eliminating unnecessary dependencies.  
- **Improve code clarity** by removing boilerplate imports that are no longer needed.
