### PR TITLE
chore: migrate deprecated MUI APIs

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -189,14 +189,16 @@ const NavBar: React.FC<NavBarProps> = () => {
         >
           <ListItemText
             primary={text}
-            primaryTypographyProps={{
-              variant: "h6",
-              sx: { textAlign: "center" },
+            slotProps={{
+              primary: {
+                variant: "h6",
+                sx: { textAlign: "center" },
+              }
             }}
           />
         </ListItemButton>
       </Link>
-    )
+    );
   }
 
   const drawer = (
@@ -291,20 +293,22 @@ const NavBar: React.FC<NavBarProps> = () => {
           ModalProps={{
             keepMounted: true,
           }}
-          PaperProps={{
-            sx: { width: "100vw", height: "100vh" },
-          }}
           sx={{
             sm: "block",
             md: "none",
             "& .MuiDrawer-paper": { boxSizing: "border-box" },
+          }}
+          slotProps={{
+            paper: {
+              sx: { width: "100vw", height: "100vh" },
+            }
           }}
         >
           {drawer}
         </Drawer>
       </nav>
     </Box>
-  )
+  );
 }
 
 export default NavBar

--- a/src/app/components/Projects/SideBarModal.tsx
+++ b/src/app/components/Projects/SideBarModal.tsx
@@ -85,13 +85,15 @@ const SideBarModal: React.FC<ISideBarModal> = ({
       onClose={closeShow}
       aria-labelledby="product-modal-title"
       aria-describedby="product-modal-description"
-      PaperProps={{
-        style: {
-          padding: "1.5rem",
-        },
-        sx: {
-          width: drawerWidth,
-        },
+      slotProps={{
+        paper: {
+          style: {
+            padding: "1.5rem",
+          },
+          sx: {
+            width: drawerWidth,
+          },
+        }
       }}
     >
       <Box sx={{ position: "relative", height: "100%" }}>
@@ -285,7 +287,7 @@ const SideBarModal: React.FC<ISideBarModal> = ({
         </CustomLink>
       </Box>
     </Drawer>
-  )
+  );
 }
 
 export default SideBarModal


### PR DESCRIPTION
This runs the `@mui/codemod@latest deprecations/all` to automatically update deprecated APIs in MUI to the current recommended usage.

This ensures code consistency and compatibility with the latest MUI versions, avoiding future issues with deprecated components and props.