### PR TITLE
fix: Use Correct Motion Props for Intro Section in ContactContent

### DIFF
--- a/src/app/components/Contact/ContactContent.tsx
+++ b/src/app/components/Contact/ContactContent.tsx
@@ -156,7 +156,7 @@ const ContactContent: React.FC = () => {
               </Typography>
             </motion.div>
             <article>
-              <motion.div {...motionPropsHeading}>
+              <motion.div {...motionPropsIntro}>
                 <Typography
                   variant="body2"
                   component="p"


### PR DESCRIPTION
## Summary

This PR fixes a small issue where the intro section of the `ContactContent` component was using `motionPropsHeading` instead of the intended `motionPropsIntro`. Now, the correct transition props are applied, ensuring consistent and expected animation timing across the component.

### Changes:

  - Updated the motion props for the intro section to use `motionPropsIntro`.

No other functionality is affected.

