### PR TITLE
ci(dependabot): remove conflicting npm config and increase PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "04:00"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     rebase-strategy: "auto"
     versioning-strategy: "widen"
     labels:
@@ -19,13 +19,6 @@ updates:
       include: "scope"
     allow:
       - dependency-type: "direct"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    security-updates-only: true
-    open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Overview

Fixes a misconfiguration in `.github/dependabot.yml` that prevented Dependabot from functioning correctly for npm updates.

### Changes

- Removed the duplicate `npm` update block using `security-updates-only: true`
- Raised `open-pull-requests-limit` from 5 → 10

### Context

Dependabot does not support multiple configurations for the same `package-ecosystem` and `directory`. The duplicate block caused the npm updater to silently fail.

With this fix, Dependabot should resume creating PRs for npm dependencies as expected.
