### PR TITLE
docs(readme): rewrite README and add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 peppapig450
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,43 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Nick's Portfolio
 
-## Getting Started
+[![Next.js](https://img.shields.io/badge/Next.js-15.3.3-000?logo=next.js)](https://nextjs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.8.3-3178c6?logo=typescript)](https://www.typescriptlang.org/)
+[![MUI](https://img.shields.io/badge/MUI-6.4.12-007fff?logo=mui)](https://mui.com/)
+[![Framer Motion](https://img.shields.io/badge/Framer_Motion-10.16.4-0055FF?logo=framer)](https://www.framer.com/motion/)
+[![Vercel](https://img.shields.io/badge/deployed-Vercel-000?logo=vercel)](https://nickbrady.dev/)
+[![Lint & Format](https://github.com/peppapig450/portfolio-v2/actions/workflows/lint.yml/badge.svg)](https://github.com/peppapig450/portfolio-v2/actions/workflows/lint.yml)
+[![Open PRs](https://img.shields.io/github/issues-pr/peppapig450/portfolio-v2?color=informational)](https://github.com/peppapig450/portfolio-v2/pulls)
+[![GitHub stars](https://img.shields.io/github/stars/peppapig450/portfolio-v2?style=social)](https://github.com/peppapig450/portfolio-v2)
 
-First, run the development server:
+## Overview
+
+Welcome! This repo powers my personal portfolio site built with **Next.js**, **Framer Motion**, and **MUI**. It's a snapshot of my work as a versatile developer. Potential collaborators and employers can explore projects, read my write-ups, view my development approach, and see what I'm currently tinkering with.
+
+## Running Locally
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+
+git clone https://github.com/peppapig450/portfolio-v2
+cd portfolio-v2
+
+pnpm install
+pnpm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Visit `http://localhost:3000` in your browser, and you're good to go!
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Tech Stack
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+- **Next.js** for the framework
+- **TypeScript** for static typing
+- **MUI** for the component library
+- **Framer Motion** for fluid, interactive animations
+- **Vercel** for hosting and analytics
 
-## Learn More
+## Contributing
 
-To learn more about Next.js, take a look at the following resources:
+Feel free to open issues or submit pull requests if you spot something that could be improved.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## License
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+This project is open source under the MIT license.


### PR DESCRIPTION
## Summary

This PR improves the developer onboarding experience by updating the `README.md` and adding an open source license.

## Changes

- Rewrote the `README.md` with a personalized project overview and clearer structure
  - Added technology badges (Next.js, TypeScript, MUI, Framer Motion, Vercel)
  - Replaced boilerplate with a concise project description
  - Added updated local development instructions (`pnpm`)
  - Introduced tech stack, contributing guidelines, and licensing info
- Added `LICENSE` file with the MIT License

## Motivation

The default Next.js README did not reflect the purpose or stack of this portfolio. This update improves clarity for visitors, potential collaborators, and recruiters. Adding the MIT license clarifies usage rights and encourages contributions.

## Preview

> View the updated README at [nickbrady.dev](https://nickbrady.dev)

## Checklist

- [x] Documentation updated
- [x] License added
