### PR TITLE
ci: fix invalid permission key in update_readme_badges.yml

### DIFF
--- a/.github/workflows/update_readme_badges.yml
+++ b/.github/workflows/update_readme_badges.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  pull_requests: write
+  pull-requests: write
   contents: write
 
 jobs:


### PR DESCRIPTION
### Summary

This PR fixes a YAML syntax error in the `.github/workflows/update_readme_badges.yml` file caused by an invalid permission key.

### What Changed

- Replaced `pull_requests: write` with `pull-requests: write` under the `permissions` block.

### Why It Matters

GitHub Actions was failing to parse the workflow file due to the incorrect permission key. This fix restores workflow validity, ensuring that the necessary permissions are granted for modifying pull requests and repository contents.

### References

- [GitHub Actions Permissions Documentation](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

