### PR TITLE
[Feat] React 19 Component Patterns Migration

### DIFF
--- a/src/app/components/CustomTabs.tsx
+++ b/src/app/components/CustomTabs.tsx
@@ -2,7 +2,7 @@ import { TabContext, TabList, TabPanel } from "@mui/lab"
 import type { BoxProps } from "@mui/material"
 import { Box, Tab } from "@mui/material"
 import { styled } from "@mui/material/styles"
-import { forwardRef, useState } from "react"
+import { useState, type Ref } from "react"
 
 const StyledTab = styled(Tab)(({ theme }) => ({
   backgroundColor: "transparent",
@@ -22,60 +22,64 @@ interface TabItem {
   content: React.ReactNode
   href?: string
 }
-
-interface CustomTabProps {
+type CustomTabProps = {
   items: TabItem[]
+} & BoxProps & {
+    ref?: Ref<HTMLDivElement>
+  }
+
+const CustomTabs = ({
+  items,
+  sx: userSx = {},
+  ref,
+  ...otherProps
+}: CustomTabProps) => {
+  const [value, setValue] = useState<string>("0")
+
+  const handleChange = (event: React.SyntheticEvent, newValue: string) => {
+    setValue(newValue)
+  }
+
+  return (
+    <Box
+      ref={ref}
+      component="nav"
+      {...otherProps}
+      sx={{
+        width: "100%",
+        typography: "body1",
+        margin: "auto",
+        ...userSx,
+      }}
+    >
+      <TabContext value={value}>
+        <Box borderColor="divider" borderBottom="1">
+          <TabList
+            onChange={handleChange}
+            aria-label="Project navigation tabs"
+            centered
+            sx={{
+              padding: "10px",
+            }}
+          >
+            {items.map((item, index) => (
+              <StyledTab
+                key={index}
+                label={item.label}
+                value={index.toString()}
+              />
+            ))}
+          </TabList>
+        </Box>
+        {items.map((item, index) => (
+          <TabPanel key={index} value={index.toString()}>
+            {item.content}
+          </TabPanel>
+        ))}
+      </TabContext>
+    </Box>
+  )
 }
-
-const CustomTabs = forwardRef<HTMLDivElement, CustomTabProps & BoxProps>(
-  ({ items, sx: userSx = {}, ...otherProps }, ref) => {
-    const [value, setValue] = useState<string>("0")
-
-    const handleChange = (event: React.SyntheticEvent, newValue: string) => {
-      setValue(newValue)
-    }
-
-    return (
-      <Box
-        ref={ref}
-        component="nav"
-        {...otherProps}
-        sx={{
-          width: "100%",
-          typography: "body1",
-          margin: "auto",
-          ...userSx,
-        }}
-      >
-        <TabContext value={value}>
-          <Box borderColor="divider" borderBottom="1">
-            <TabList
-              onChange={handleChange}
-              aria-label="Project navigation tabs"
-              centered
-              sx={{
-                padding: "10px",
-              }}
-            >
-              {items.map((item, index) => (
-                <StyledTab
-                  key={index}
-                  label={item.label}
-                  value={index.toString()}
-                />
-              ))}
-            </TabList>
-          </Box>
-          {items.map((item, index) => (
-            <TabPanel key={index} value={index.toString()}>
-              {item.content}
-            </TabPanel>
-          ))}
-        </TabContext>
-      </Box>
-    )
-  },
-)
 
 CustomTabs.displayName = "CustomTabs"
 

--- a/src/app/components/FooterLink.tsx
+++ b/src/app/components/FooterLink.tsx
@@ -14,7 +14,7 @@ import type {
 import { Box, IconButton, Link, Typography, useTheme } from "@mui/material"
 import { styled } from "@mui/material/styles"
 import NextLink from "next/link"
-import { forwardRef } from "react"
+import type { Ref } from "react"
 import CustomLink from "./CustomLink"
 
 interface FooterLinkProps extends Omit<LinkProps, "component"> {
@@ -52,127 +52,130 @@ const SocialMediaBox = styled(Box)<BoxProps>(({ theme }) => ({
   background: "transparent",
   padding: theme.spacing(2, 0),
 }))
+const FooterLinkComponent = ({
+  children,
+  goto = "/",
+  sx: userSx = {},
+  ref,
+  ...otherProps
+}: FooterLinkProps & { ref?: Ref<HTMLElement> }) => {
+  const theme = useTheme()
 
-const FooterLinkComponent = forwardRef<HTMLElement, FooterLinkProps>(
-  ({ children, goto = "/", sx: userSx = {}, ...otherProps }, ref) => {
-    const theme = useTheme()
+  const SocialMedias: SocialMediaItems[] = [
+    {
+      icon: <TwitterIcon aria-hidden="true" />,
+      url: "https://twitter.com/nickdidthat22",
+      label: "Twitter",
+    },
+    {
+      icon: <FacebookIcon aria-hidden="true" />,
+      url: "https://www.facebook/nickdidthat22",
+      label: "Facebook",
+    },
+    {
+      icon: <LinkedInIcon aria-hidden="true" />,
+      url: "https://www.linkedin.com/in/nick-brady-5715752b3",
+      label: "LinkedIn",
+    },
+    {
+      icon: <GitHubIcon aria-hidden="true" />,
+      url: "https://github.com/peppapig450",
+      label: "GitHub",
+    },
+    {
+      icon: <InstagramIcon aria-hidden="true" />,
+      url: "https://instagram.com/nickbrady41",
+      label: "Instagram",
+    },
+  ]
 
-    const SocialMedias: SocialMediaItems[] = [
-      {
-        icon: <TwitterIcon aria-hidden="true" />,
-        url: "https://twitter.com/nickdidthat22",
-        label: "Twitter",
-      },
-      {
-        icon: <FacebookIcon aria-hidden="true" />,
-        url: "https://www.facebook/nickdidthat22",
-        label: "Facebook",
-      },
-      {
-        icon: <LinkedInIcon aria-hidden="true" />,
-        url: "https://www.linkedin.com/in/nick-brady-5715752b3",
-        label: "LinkedIn",
-      },
-      {
-        icon: <GitHubIcon aria-hidden="true" />,
-        url: "https://github.com/peppapig450",
-        label: "GitHub",
-      },
-      {
-        icon: <InstagramIcon aria-hidden="true" />,
-        url: "https://instagram.com/nickbrady41",
-        label: "Instagram",
-      },
-    ]
-
-    return (
-      <Box
-        component="footer"
-        ref={ref}
-        {...otherProps} // everything except sx
-        sx={{
-          mt: 4,
-          [theme.breakpoints.down("md")]: {
-            paddingBottom: 5,
-          },
-          // merge in user overrides
-          ...userSx,
-        }}
+  return (
+    <Box
+      component="footer"
+      ref={ref}
+      {...otherProps} // everything except sx
+      sx={{
+        mt: 4,
+        [theme.breakpoints.down("md")]: {
+          paddingBottom: 5,
+        },
+        // merge in user overrides
+        ...userSx,
+      }}
+    >
+      <Link
+        href={goto}
+        underline="none"
+        component={NextLink}
+        passHref
+        aria-label={`Navigate to ${goto} page`}
       >
-        <Link
-          href={goto}
-          underline="none"
-          component={NextLink}
-          passHref
-          aria-label={`Navigate to ${goto} page`}
-        >
-          <Box sx={{ display: "inline-flex", alignItems: "center" }}>
-            <AnimatedTypography
+        <Box sx={{ display: "inline-flex", alignItems: "center" }}>
+          <AnimatedTypography
+            sx={{
+              fontSize: theme.typography.body1.fontSize,
+              fontWeight: theme.typography.fontWeightMedium,
+              color: theme.palette.grey[800],
+              display: "inline-flex",
+              alignItems: "center",
+            }}
+          >
+            {children}
+          </AnimatedTypography>
+          <ArrowRightAltIcon
+            aria-hidden="true"
+            sx={{
+              fontSize: "60px",
+              ml: theme.spacing(1),
+              color: theme.palette.secondary.main,
+              animation: `${arrowBounce} 0.5s infinite alternate`,
+              "@media (prefers-reduced-motion: reduce)": {
+                animation: "none",
+                transform: "translateX(1rem)",
+              },
+            }}
+          />
+        </Box>
+      </Link>
+      <SocialMediaBox sx={{ mr: -3 }}>
+        {SocialMedias.map((social, index) => (
+          <CustomLink
+            href={social.url}
+            key={index}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`${social.label} Page`}
+            aria-label={`Visit Nick Brady's ${social.label} page`}
+            sx={{
+              mr: 0,
+              transition: "all 1s ease",
+              cursor: "pointer",
+              p: theme.spacing(1, 1.5),
+              "&:first-of-type": { pl: 0 },
+            }}
+          >
+            <IconButton
+              aria-label={`Go to Nick Brady's ${social.label} Page`}
               sx={{
-                fontSize: theme.typography.body1.fontSize,
-                fontWeight: theme.typography.fontWeightMedium,
-                color: theme.palette.grey[800],
-                display: "inline-flex",
-                alignItems: "center",
-              }}
-            >
-              {children}
-            </AnimatedTypography>
-            <ArrowRightAltIcon
-              aria-hidden="true"
-              sx={{
-                fontSize: "60px",
-                ml: theme.spacing(1),
-                color: theme.palette.secondary.main,
-                animation: `${arrowBounce} 0.5s infinite alternate`,
-                "@media (prefers-reduced-motion: reduce)": {
-                  animation: "none",
-                  transform: "translateX(1rem)",
+                cursor: "pointer",
+                height: 15,
+                fill: theme.palette.text.secondary,
+                transition: "all 1s ease",
+                "&:hover": {
+                  stroke: theme.palette.text.secondary,
+                  strokeWidth: 1,
+                  strokeOpacity: 0.8,
                 },
               }}
-            />
-          </Box>
-        </Link>
-        <SocialMediaBox sx={{ mr: -3 }}>
-          {SocialMedias.map((social, index) => (
-            <CustomLink
-              href={social.url}
-              key={index}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={`${social.label} Page`}
-              aria-label={`Visit Nick Brady's ${social.label} page`}
-              sx={{
-                mr: 0,
-                transition: "all 1s ease",
-                cursor: "pointer",
-                p: theme.spacing(1, 1.5),
-                "&:first-of-type": { pl: 0 },
-              }}
             >
-              <IconButton
-                aria-label={`Go to Nick Brady's ${social.label} Page`}
-                sx={{
-                  cursor: "pointer",
-                  height: 15,
-                  fill: theme.palette.text.secondary,
-                  transition: "all 1s ease",
-                  "&:hover": {
-                    stroke: theme.palette.text.secondary,
-                    strokeWidth: 1,
-                    strokeOpacity: 0.8,
-                  },
-                }}
-              >
-                {social.icon}
-              </IconButton>
-            </CustomLink>
-          ))}
-        </SocialMediaBox>
-      </Box>
-    )
-  },
-)
+              {social.icon}
+            </IconButton>
+          </CustomLink>
+        ))}
+      </SocialMediaBox>
+    </Box>
+  )
+}
 
 FooterLinkComponent.displayName = "FooterLink"
 export default FooterLinkComponent

--- a/src/app/components/LandingPage/AnimatedTitle.tsx
+++ b/src/app/components/LandingPage/AnimatedTitle.tsx
@@ -2,9 +2,12 @@ import { noiseAnim, noiseAnim2 } from "@/styles/keyframes"
 import type { BoxProps } from "@mui/material"
 import { Box, Typography } from "@mui/material"
 import { useTheme } from "@mui/material/styles"
-import { forwardRef } from "react"
+import type { Ref } from "react"
 
-const AnimatedTitle = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
+const AnimatedTitle = ({
+  ref,
+  ...props
+}: BoxProps & { ref?: Ref<HTMLDivElement> }) => {
   const theme = useTheme()
 
   return (
@@ -62,7 +65,7 @@ const AnimatedTitle = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
       </Typography>
     </Box>
   )
-})
+}
 
 AnimatedTitle.displayName = "AnimatedTitle"
 

--- a/src/app/components/LandingPage/IntroductionText.tsx
+++ b/src/app/components/LandingPage/IntroductionText.tsx
@@ -1,10 +1,12 @@
 import type { BoxProps } from "@mui/material"
 import { Box, Typography } from "@mui/material"
 import { useTheme } from "@mui/material/styles"
-import { forwardRef } from "react"
+import type { Ref } from "react"
 import CustomLink from "../CustomLink"
 
-const IntroductionText = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
+type IntroductionTextProps = BoxProps & { ref?: Ref<HTMLDivElement> }
+
+const IntroductionText = ({ ref, ...props }: IntroductionTextProps) => {
   const theme = useTheme()
 
   return (
@@ -86,7 +88,7 @@ const IntroductionText = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
       </Typography>
     </Box>
   )
-})
+}
 
 IntroductionText.displayName = "IntroductionText"
 

--- a/src/app/components/StaggeredContainer.tsx
+++ b/src/app/components/StaggeredContainer.tsx
@@ -1,14 +1,7 @@
 "use client"
 
 import { isMotionComponent, motion, useReducedMotion } from "framer-motion"
-import {
-  Children,
-  cloneElement,
-  forwardRef,
-  isValidElement,
-  memo,
-  useMemo,
-} from "react"
+import { Children, cloneElement, isValidElement, memo, useMemo } from "react"
 
 import type { MotionProps, Variants } from "framer-motion"
 import type {
@@ -19,6 +12,7 @@ import type {
   PropsWithChildren,
   ReactElement,
   ReactNode,
+  Ref,
 } from "react"
 
 interface StaggeredContainerOwnProps extends PropsWithChildren {
@@ -30,18 +24,26 @@ interface StaggeredContainerOwnProps extends PropsWithChildren {
   variant?: Variants
 }
 
+type PolymorphicRef<T extends ElementType> = Ref<
+  // Extract the *instance* we’ll actually receive in the ref:
+  //   – DOM nodes for intrinsic tags (e.g. "div" → HTMLDivElement)
+  //   – the class instance for class components
+  //   – never for plain function components (they have no instance)
+  //
+  // ComponentPropsWithRef already does this dance for us, so we can reuse it:>
+  ComponentPropsWithRef<T> extends { ref?: Ref<infer R> } ? R : never
+>
+
 /**
  * Merges the container's own props, Framer Motion's MotionProps,
  * and the props of the wrapped component T (omitting any conflicts).
  */
 type PolymorphicProps<T extends ElementType> = StaggeredContainerOwnProps & // own props
-  MotionProps & // Framer Motion base props
+  MotionProps &
   Omit<ComponentPropsWithoutRef<T>, keyof StaggeredContainerOwnProps> & {
     as?: T
-  } // polymorphic "as"
-
-/** Helper to get the right `ref` for any element/component */
-type PolymorphicRef<T extends ElementType> = ComponentPropsWithRef<T>["ref"]
+    ref?: PolymorphicRef<T>
+  }
 
 /**
  * What the *public* component should look like once all the casting is done.
@@ -49,7 +51,7 @@ type PolymorphicRef<T extends ElementType> = ComponentPropsWithRef<T>["ref"]
 export type ForwardRefWithAs<DefaultAs extends ElementType> = <
   As extends ElementType = DefaultAs,
 >(
-  props: PolymorphicProps<As> & { ref?: PolymorphicRef<As> },
+  props: PolymorphicProps<As>,
 ) => JSX.Element
 
 /**
@@ -95,17 +97,15 @@ const toMotion = <T extends ElementType>(component: T) => {
  * behavior; it will be wrapped and re‑typed before export so consumers get a
  * proper polymorphic experience.
  */
-const StaggeredContainerInner = <T extends ElementType = "div">(
-  {
-    as,
-    children,
-    staggerDelay = 0.2,
-    initialDelay = 0.1,
-    variant = revealChildVariant,
-    ...rest
-  }: PolymorphicProps<T>,
-  ref: PolymorphicRef<T>,
-) => {
+const StaggeredContainerInner = <T extends ElementType = "div">({
+  as,
+  children,
+  staggerDelay = 0.2,
+  initialDelay = 0.1,
+  variant = revealChildVariant,
+  ref,
+  ...rest
+}: PolymorphicProps<T>) => {
   const shouldReduceMotion = useReducedMotion()
 
   /**
@@ -182,22 +182,13 @@ const StaggeredContainerInner = <T extends ElementType = "div">(
 }
 
 /**
- * `forwardRef` doesn’t keep the generic, so we cast *after* creating the
- * component to re‑expose the polymorphic signature.
- */
-const Forwarded = forwardRef(
-  StaggeredContainerInner as unknown as (
-    props: PolymorphicProps<ElementType>,
-    ref: PolymorphicRef<ElementType>,
-  ) => JSX.Element,
-)
-
-/**
  * A container that staggers its children's animations on mount.
  * Supports polymorphic "as" to render any HTML or custom component,
  * with full props and ref forwarding.
  *
  * This component is memoized to prevent unnecessary re-renders.
  */
-export const StaggeredContainer = memo(Forwarded) as ForwardRefWithAs<"div">
+export const StaggeredContainer = memo(
+  StaggeredContainerInner,
+) as ForwardRefWithAs<"div">
 StaggeredContainerInner.displayName = "StaggeredContentInner"

--- a/src/contexts/AboutContext.tsx
+++ b/src/contexts/AboutContext.tsx
@@ -138,7 +138,5 @@ export default function AboutProvider({
     ],
   }
 
-  return (
-    <AboutContext.Provider value={aboutData}>{children}</AboutContext.Provider>
-  )
+  return <AboutContext value={aboutData}>{children}</AboutContext>
 }

--- a/src/contexts/ProjectsContext.tsx
+++ b/src/contexts/ProjectsContext.tsx
@@ -86,11 +86,7 @@ export const ProjectsProvider: React.FC<{ children: ReactNode }> = ({
     getProjectsByType,
   }
 
-  return (
-    <ProjectsContext.Provider value={value}>
-      {children}
-    </ProjectsContext.Provider>
-  )
+  return <ProjectsContext value={value}>{children}</ProjectsContext>
 }
 
 // Custom hook to use the projects context


### PR DESCRIPTION
## Overview
This PR migrates our component architecture from React 18 patterns to React 19 patterns, focusing on ref handling and context provider syntax. This is the first sub-PR in Phase 1 of our React 19 migration, establishing modern component patterns before the upcoming portfolio refactor.

## Completed Work

### Component Ref Pattern Migration
- **StaggeredContainer**: Complete polymorphic ref migration
  - Removed `forwardRef` wrapper entirely  
  - Defined `PolymorphicRef<T>` using `React.Ref<>` and `ComponentPropsWithRef`
  - Preserved memoization, polymorphic "as" prop, and all motion logic
- **Simple Components**: Migrated 5+ components to direct ref props
  - `CustomTabs`, `FooterLink`, `AnimatedTitle`, `IntroductionText`
  - Removed forwardRef wrappers, pull `ref` directly from props
  - Added proper TypeScript `Ref<T>` typing

### Context Provider Modernization
- **ProjectsContext**: Updated to React 19 context syntax
  - Removed `.Provider` wrapper, use direct context component
  - Maintained all existing functionality and type safety
- **AboutContext**: Updated to React 19 context syntax
  - Consistent pattern with ProjectsContext
  - No changes to context consumer usage

## Component Migration Details

### StaggeredContainer (Complex Migration)
- **Challenge**: Polymorphic component with forwardRef and complex TypeScript
- **Solution**: Direct ref prop with properly typed `PolymorphicRef<T>`
- **Result**: Cleaner code, better TypeScript experience, same functionality

### Simple Components (Straightforward Migration)
- **Pattern**: `forwardRef<ElementType, Props>` → `{ ref?: Ref<ElementType> }`
- **TypeScript**: Added explicit `Ref<T>` imports and prop typing
- **Functionality**: Identical behavior, simpler implementation

### Context Providers (Syntax Update)
- **Before**: `<Context.Provider value={data}>{children}</Context.Provider>`
- **After**: `<Context value={data}>{children}</Context>`
- **Impact**: Modern React 19 syntax, no consumer changes needed

## Testing Completed
- [x] **Ref forwarding works correctly** in all migrated components
- [x] **StaggeredContainer animations** function identically to before
- [x] **Context providers** supply data correctly to all consumers
- [x] **TypeScript compilation** passes without errors
- [x] **Component rendering** unchanged - no visual regressions
- [x] **Framer Motion integration** still works with new ref patterns

## Files Changed
- `src/app/components/StaggeredContainer.tsx` - Polymorphic ref migration
- `src/app/components/CustomTabs.tsx` - Direct ref props
- `src/app/components/FooterLink.tsx` - Direct ref props
- `src/app/components/LandingPage/AnimatedTitle.tsx` - Direct ref props
- `src/app/components/LandingPage/IntroductionText.tsx` - Direct ref props
- `src/contexts/AboutContext.tsx` - React 19 context syntax
- `src/contexts/ProjectsContext.tsx` - React 19 context syntax

## Breaking Changes
- Components now expect `ref` as a direct prop instead of through forwardRef
- Changes are backward compatible - no consumer code changes needed
- Context provider usage unchanged (internal implementation only)

## Next Steps in Phase 1
This PR is **Part 1 of 4** in the React 19 Phase 1 migration:

Closes #58 