### PR TITLE
ci(lint): optimize workflow with path filters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,16 @@ name: Lint & Format
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'images/**'
+      - '**.png'
+      - '**.jpg'
 
 jobs:
   lint:


### PR DESCRIPTION
## What
Optimizes the lint workflow to skip unnecessary runs on non-code changes.

## Why
- Reduces CI usage when only docs/assets are modified
- Faster feedback on actual code changes
- More efficient use of GitHub Actions minutes

## Changes
- Added specific PR event types (opened, synchronize, reopened)
- Added path exclusions for markdown files, images, and other non-code assets
