### PR TITLE
chore: use absolute tsconfig root for ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig([
 
       parserOptions: {
         project: "./tsconfig.json",
-        tsconfigRootDir: ".",
+        tsconfigRootDir: path.dirname(fileURLToPath(import.meta.url)),
       },
     },
 


### PR DESCRIPTION
## Summary
- ensure ESLint uses absolute tsconfig root path

## Testing
- `pnpm exec prettier --write .`
- `pnpm run lint`
- `pnpm run build` *(fails: Failed to fetch `Labrada` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3fbba830832eac76c35236890fa3